### PR TITLE
Fix GPU detection, DGX Spark/GB10 support, Node runtime guard, and tooling comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,20 @@ Choosing the right LLM for your hardware is complex. With thousands of model var
 
 ---
 
+## Comparison with Other Tooling (e.g. `llmfit`)
+
+LLM Checker and `llmfit` solve related but different problems:
+
+| Tool | Primary Focus | Typical Output |
+|------|---------------|----------------|
+| **LLM Checker** | Hardware-aware **model selection** for local inference | Ranked recommendations, compatibility scores, pull/run commands |
+| **llmfit** | LLM workflow support and model-fit evaluation from another angle | Different optimization workflow and selection heuristics |
+
+If your goal is: *"What should I run on this exact machine right now?"*, use **LLM Checker** first.  
+If your goal is broader experimentation across custom pipelines, using both tools can be complementary.
+
+---
+
 ## Installation
 
 ```bash

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+'use strict';
+
+const majorNodeVersion = Number.parseInt(process.versions.node.split('.')[0], 10);
+
+if (!Number.isFinite(majorNodeVersion) || majorNodeVersion < 16) {
+    console.error(
+        `[llm-checker] Unsupported Node.js version: ${process.versions.node}. ` +
+        'Please use Node.js 16 or newer.'
+    );
+    process.exit(1);
+}
+
+require('./enhanced_cli');

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "3.2.0",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
-    "llm-checker": "bin/enhanced_cli.js",
-    "ollama-checker": "bin/enhanced_cli.js",
+    "llm-checker": "bin/cli.js",
+    "ollama-checker": "bin/cli.js",
     "llm-checker-mcp": "bin/mcp-server.mjs"
   },
   "main": "src/index.js",
@@ -14,6 +14,7 @@
     "test:platform": "node tests/platform-tests/cross-platform.test.js",
     "test:ui": "node tests/ui-tests/interface.test.js",
     "test:runtime": "node tests/runtime-specdec-tests.js",
+    "test:hardware-detector": "node tests/hardware-detector-regression.js",
     "test:all": "node tests/run-all-tests.js",
     "build": "echo 'No build needed'",
     "dev": "node bin/enhanced_cli.js",

--- a/src/hardware/backends/cuda-detector.js
+++ b/src/hardware/backends/cuda-detector.js
@@ -209,8 +209,34 @@ class CUDADetector {
             architecture: 'Unknown'
         };
 
+        // NVIDIA GB10 / Grace Blackwell (DGX Spark)
+        if (nameLower.includes('gb10') || nameLower.includes('grace blackwell') ||
+            nameLower.includes('dgx spark') || nameLower.includes('blackwell')) {
+            capabilities.tensorCores = true;
+            capabilities.bf16 = true;
+            capabilities.fp8 = true;
+            capabilities.computeCapability = '10.0';
+            capabilities.architecture = 'Grace Blackwell';
+        }
+        // H100 (Hopper)
+        else if (nameLower.includes('h100') || nameLower.includes('h200')) {
+            capabilities.tensorCores = true;
+            capabilities.bf16 = true;
+            capabilities.fp8 = true;
+            capabilities.nvlink = true;
+            capabilities.computeCapability = '9.0';
+            capabilities.architecture = 'Hopper';
+        }
+        // Tesla P100 (Pascal)
+        else if (nameLower.includes('p100') || nameLower.includes('tesla p100')) {
+            capabilities.tensorCores = false;
+            capabilities.bf16 = false;
+            capabilities.fp8 = false;
+            capabilities.computeCapability = '6.0';
+            capabilities.architecture = 'Pascal';
+        }
         // RTX 50 series (Blackwell)
-        if (nameLower.includes('rtx 50') || nameLower.includes('rtx50')) {
+        else if (nameLower.includes('rtx 50') || nameLower.includes('rtx50')) {
             capabilities.tensorCores = true;
             capabilities.bf16 = true;
             capabilities.fp8 = true;
@@ -257,15 +283,6 @@ class CUDADetector {
             capabilities.architecture = 'Volta';
             capabilities.nvlink = true;
         }
-        // H100 (Hopper)
-        else if (nameLower.includes('h100') || nameLower.includes('h200')) {
-            capabilities.tensorCores = true;
-            capabilities.bf16 = true;
-            capabilities.fp8 = true;
-            capabilities.nvlink = true;
-            capabilities.computeCapability = '9.0';
-            capabilities.architecture = 'Hopper';
-        }
 
         return capabilities;
     }
@@ -311,6 +328,9 @@ class CUDADetector {
             'rtx 2060': 80,
 
             // Data center
+            'gb10': 95,
+            'grace blackwell': 95,
+            'dgx spark': 95,
             'h100': 400,
             'h200': 450,
             'a100': 300,
@@ -318,7 +338,8 @@ class CUDADetector {
             'l4': 150,
             'a40': 180,
             't4': 70,
-            'v100': 120
+            'v100': 120,
+            'p100': 45
         };
 
         for (const [model, speed] of Object.entries(speedMap)) {

--- a/src/hardware/specs.js
+++ b/src/hardware/specs.js
@@ -71,6 +71,13 @@ class HardwareSpecs {
             'NVIDIA GeForce RTX 3060 Ti': { score: 75, vram: 8, tdp: 200, dedicated: true },
             'NVIDIA GeForce RTX 3060': { score: 70, vram: 12, tdp: 170, dedicated: true },
 
+            // NVIDIA Data Center / Workstation
+            'NVIDIA H100': { score: 100, vram: 80, tdp: 700, dedicated: true },
+            'NVIDIA A100': { score: 94, vram: 80, tdp: 400, dedicated: true },
+            'NVIDIA Tesla P100': { score: 74, vram: 16, tdp: 250, dedicated: true },
+            'NVIDIA GB10 Grace Blackwell': { score: 96, vram: 96, tdp: 140, dedicated: true },
+            'NVIDIA DGX Spark (GB10)': { score: 96, vram: 96, tdp: 140, dedicated: true },
+
             // AMD RX 7000 Series
             'AMD Radeon RX 7900 XTX': { score: 92, vram: 24, tdp: 355, dedicated: true },
             'AMD Radeon RX 7900 XT': { score: 88, vram: 20, tdp: 300, dedicated: true },

--- a/src/models/expanded_database.js
+++ b/src/models/expanded_database.js
@@ -999,10 +999,16 @@ class ExpandedModelsDatabase {
         } else if (hasDedicatedGPU) {
             // Dedicated GPU - much better performance
             let gpuTPS = 30;
-            if (gpuModel.toLowerCase().includes('rtx 50')) gpuTPS = 65;
+            if (gpuModel.toLowerCase().includes('gb10') ||
+                gpuModel.toLowerCase().includes('grace blackwell') ||
+                gpuModel.toLowerCase().includes('dgx spark')) gpuTPS = 90;
+            else if (gpuModel.toLowerCase().includes('h100')) gpuTPS = 120;
+            else if (gpuModel.toLowerCase().includes('a100')) gpuTPS = 95;
+            else if (gpuModel.toLowerCase().includes('rtx 50')) gpuTPS = 65;
             else if (gpuModel.toLowerCase().includes('rtx 40')) gpuTPS = 50;
             else if (gpuModel.toLowerCase().includes('rtx 30')) gpuTPS = 40;
             else if (gpuModel.toLowerCase().includes('rtx 20')) gpuTPS = 30;
+            else if (gpuModel.toLowerCase().includes('p100')) gpuTPS = 32;
             else if (vramGB >= 16) gpuTPS = 45;
             else if (vramGB >= 8) gpuTPS = 35;
             else if (vramGB >= 4) gpuTPS = 25;

--- a/src/models/scoring-engine.js
+++ b/src/models/scoring-engine.js
@@ -170,6 +170,7 @@ class ScoringEngine {
             // NVIDIA - based on real llama.cpp/Ollama benchmarks
             'cuda_h100': 120,    // ~100-140 TPS for 7B Q4
             'cuda_a100': 90,     // ~80-100 TPS for 7B Q4
+            'cuda_gb10': 95,     // Grace Blackwell / DGX Spark class
             'cuda_4090': 70,     // ~60-80 TPS for 7B Q4
             'cuda_4080': 55,     // ~50-60 TPS for 7B Q4
             'cuda_3090': 50,     // ~45-55 TPS for 7B Q4
@@ -177,6 +178,7 @@ class ScoringEngine {
             'cuda_3070': 32,     // ~28-35 TPS for 7B Q4
             'cuda_3060': 25,     // ~20-28 TPS for 7B Q4
             'cuda_2080': 28,     // ~25-30 TPS for 7B Q4
+            'cuda_p100': 30,     // Tesla P100 class
             'cuda_default': 30,
 
             // AMD - slightly lower than equivalent NVIDIA
@@ -518,8 +520,10 @@ class ScoringEngine {
         const gpuModel = (hardware.summary.gpuModel || '').toLowerCase();
 
         if (backend === 'cuda') {
+            if (gpuModel.includes('gb10') || gpuModel.includes('grace blackwell') || gpuModel.includes('dgx spark')) return 'cuda_gb10';
             if (gpuModel.includes('h100')) return 'cuda_h100';
             if (gpuModel.includes('a100')) return 'cuda_a100';
+            if (gpuModel.includes('p100')) return 'cuda_p100';
             if (gpuModel.includes('4090')) return 'cuda_4090';
             if (gpuModel.includes('4080')) return 'cuda_4080';
             if (gpuModel.includes('3090')) return 'cuda_3090';

--- a/tests/hardware-detector-regression.js
+++ b/tests/hardware-detector-regression.js
@@ -1,0 +1,114 @@
+/**
+ * Hardware Detector Regression Tests
+ * Covers:
+ * - Vendor-less GPU entries (common in passthrough/proxmox setups)
+ * - Unified detector fallback for check/recommend path consistency
+ * - GB10 / Grace Blackwell and Tesla P100 compatibility mappings
+ */
+
+const assert = require('assert');
+const HardwareDetector = require('../src/hardware/detector');
+
+async function testVendorlessTeslaDetection() {
+    const detector = new HardwareDetector();
+    const gpu = detector.processGPUInfo({
+        controllers: [
+            {
+                model: 'Tesla P100-PCIE-16GB',
+                vendor: '',
+                vram: 16384
+            }
+        ],
+        displays: []
+    });
+
+    assert.ok(gpu.model.toLowerCase().includes('p100'), 'Tesla P100 model should be preserved');
+    assert.strictEqual(gpu.vram, 16, 'Tesla P100 VRAM should normalize to 16GB');
+    assert.strictEqual(gpu.dedicated, true, 'Tesla P100 should be treated as dedicated GPU');
+}
+
+async function testUnifiedFallbackEnrichment() {
+    const detector = new HardwareDetector();
+    detector.unifiedDetector = {
+        detect: async () => ({
+            primary: { type: 'cuda' },
+            summary: {
+                bestBackend: 'cuda',
+                gpuModel: 'NVIDIA Tesla P100',
+                totalVRAM: 64,
+                gpuCount: 4,
+                isMultiGPU: true
+            },
+            backends: {
+                cuda: {
+                    info: {
+                        driver: '550.120',
+                        gpus: [{ memory: { total: 16 } }]
+                    }
+                }
+            }
+        })
+    };
+
+    const systemInfo = {
+        cpu: {},
+        memory: {},
+        gpu: {
+            model: 'No GPU detected',
+            vendor: 'Unknown',
+            vram: 0,
+            vramPerGPU: 0,
+            dedicated: false,
+            gpuCount: 0,
+            isMultiGPU: false
+        },
+        system: {},
+        os: {}
+    };
+
+    await detector.enrichWithUnifiedHardware(systemInfo);
+
+    assert.strictEqual(systemInfo.gpu.model, 'NVIDIA Tesla P100', 'Unified detector model should override');
+    assert.strictEqual(systemInfo.gpu.vram, 64, 'Total VRAM should be taken from unified detector');
+    assert.strictEqual(systemInfo.gpu.gpuCount, 4, 'GPU count should match unified detector');
+    assert.strictEqual(systemInfo.gpu.isMultiGPU, true, 'Multi-GPU flag should be preserved');
+    assert.strictEqual(systemInfo.gpu.dedicated, true, 'CUDA backend should be treated as dedicated');
+}
+
+function testGb10AndP100Mappings() {
+    const detector = new HardwareDetector();
+
+    assert.strictEqual(
+        detector.estimateVRAMFromModel('NVIDIA GB10 Grace Blackwell'),
+        96,
+        'GB10/Grace Blackwell should map to 96GB class memory'
+    );
+    assert.ok(
+        detector.getGPUTier('NVIDIA GB10 Grace Blackwell') >= 95,
+        'GB10 should be classified as flagship-tier GPU'
+    );
+    assert.strictEqual(
+        detector.estimateVRAMFromModel('NVIDIA Tesla P100-PCIE-16GB'),
+        16,
+        'Tesla P100 should map to 16GB'
+    );
+}
+
+async function run() {
+    await testVendorlessTeslaDetection();
+    await testUnifiedFallbackEnrichment();
+    testGb10AndP100Mappings();
+    console.log('✅ hardware-detector-regression.js passed');
+}
+
+if (require.main === module) {
+    run().catch((error) => {
+        console.error('❌ hardware-detector-regression.js failed');
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = {
+    run
+};


### PR DESCRIPTION
## Summary
- fix vendor-less GPU filtering so passthrough setups (e.g. 4x Tesla P100) are detected in recommendation flow
- enrich standard hardware detection with unified backend data to keep `hw-detect` and model recommendation paths consistent
- add NVIDIA GB10 / DGX Spark and Tesla P100 mappings across detection and scoring layers
- add Node runtime guard wrapper to avoid opaque `Unexpected token` failures on unsupported Node versions
- add README comparison section for related tooling (including llmfit)
- add regression test for vendor-less GPU + unified enrichment path

## Validation
- `node tests/hardware-detector-regression.js`
- `node tests/runtime-specdec-tests.js`
- `node tests/amd-gpu-detection.test.js`
- `node bin/cli.js --help`

Fixes #13
Fixes #14
Fixes #16
Fixes #17
