### PR TITLE
feat(policy): enforce policy in check/recommend (fixes #21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:ui": "node tests/ui-tests/interface.test.js",
     "test:runtime": "node tests/runtime-specdec-tests.js",
     "test:policy": "node tests/policy-commands.test.js",
+    "test:policy-cli": "node tests/policy-cli-enforcement.js",
     "test:policy-engine": "node tests/policy-engine.test.js",
     "test:hardware-detector": "node tests/hardware-detector-regression.js",
     "test:all": "node tests/run-all-tests.js",

--- a/src/policy/cli-policy.js
+++ b/src/policy/cli-policy.js
@@ -1,0 +1,211 @@
+function isPlainObject(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function toLowerString(value) {
+    if (value === undefined || value === null) return '';
+    return String(value).trim().toLowerCase();
+}
+
+function parseParamsB(value) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
+        return value;
+    }
+
+    const text = String(value || '');
+    const match = text.match(/([0-9]+(?:\.[0-9]+)?)\s*b\b/i);
+    if (!match) return null;
+
+    return Number.parseFloat(match[1]);
+}
+
+function parseQuant(value) {
+    if (!value) return null;
+
+    const text = String(value).toLowerCase();
+    const quantMatch = text.match(
+        /(q\d(?:_[a-z0-9]+)+|q\d(?:\.[a-z0-9]+)+|q\d(?:_k)?|iq\d(?:_[a-z0-9]+)+|fp16|f16)/i
+    );
+
+    return quantMatch ? quantMatch[1].toUpperCase() : null;
+}
+
+function getModelKey(model) {
+    if (!isPlainObject(model)) return null;
+
+    const key =
+        model.model_identifier ||
+        model.modelIdentifier ||
+        model.identifier ||
+        model.tag ||
+        model.model_id ||
+        model.modelId ||
+        model.name ||
+        model.model_name;
+
+    const normalized = toLowerString(key);
+    return normalized || null;
+}
+
+function uniqueModels(models) {
+    const deduped = new Map();
+
+    (Array.isArray(models) ? models : []).forEach((model, index) => {
+        if (!isPlainObject(model)) return;
+
+        const key = getModelKey(model) || `idx:${index}`;
+        if (!deduped.has(key)) {
+            deduped.set(key, model);
+        }
+    });
+
+    return Array.from(deduped.values());
+}
+
+function collectCandidatesFromAnalysis(analysis) {
+    if (!isPlainObject(analysis)) return [];
+
+    const all = []
+        .concat(Array.isArray(analysis.compatible) ? analysis.compatible : [])
+        .concat(Array.isArray(analysis.marginal) ? analysis.marginal : []);
+
+    return uniqueModels(all);
+}
+
+function toPolicyCandidateFromSummary(modelSummary) {
+    if (!isPlainObject(modelSummary)) return null;
+
+    const identifier = modelSummary.identifier || modelSummary.model_identifier || modelSummary.name;
+    if (!identifier) return null;
+
+    const paramsB = parseParamsB(identifier) ?? parseParamsB(modelSummary.size);
+    const quant = parseQuant(identifier) || parseQuant(modelSummary.name);
+
+    return {
+        model_identifier: identifier,
+        tag: identifier,
+        name: modelSummary.name || identifier,
+        size: modelSummary.size || null,
+        params_b: paramsB,
+        quant: quant || undefined,
+        source: 'local'
+    };
+}
+
+function collectCandidatesFromRecommendationData(recommendationData) {
+    const summary = recommendationData?.summary;
+    if (!isPlainObject(summary)) return [];
+
+    const candidates = [];
+
+    if (isPlainObject(summary.by_category)) {
+        Object.values(summary.by_category).forEach((categoryModel) => {
+            const candidate = toPolicyCandidateFromSummary(categoryModel);
+            if (candidate) candidates.push(candidate);
+        });
+    }
+
+    if (isPlainObject(summary.best_overall)) {
+        const candidate = toPolicyCandidateFromSummary(summary.best_overall);
+        if (candidate) candidates.push(candidate);
+    }
+
+    return uniqueModels(candidates);
+}
+
+function buildPolicyRuntimeContext({ hardware, runtimeBackend } = {}) {
+    const summary = hardware?.summary || {};
+    const memory = hardware?.memory || {};
+
+    const bestBackend = summary.bestBackend || null;
+    const ramGB =
+        (typeof memory.total === 'number' ? memory.total : null) ??
+        (typeof summary.systemRAM === 'number' ? summary.systemRAM : null) ??
+        (typeof summary.effectiveMemory === 'number' ? summary.effectiveMemory : null);
+
+    return {
+        backend: bestBackend,
+        runtimeBackend: runtimeBackend || bestBackend,
+        ramGB,
+        totalRamGB: ramGB,
+        hardware
+    };
+}
+
+function evaluatePolicyCandidates(policyEngine, candidates, context = {}) {
+    if (!policyEngine || typeof policyEngine.evaluateModels !== 'function') {
+        throw new Error('Invalid policy engine instance.');
+    }
+
+    const evaluated = policyEngine.evaluateModels(Array.isArray(candidates) ? candidates : [], context);
+    const totalChecked = evaluated.length;
+    const passCount = evaluated.filter((item) => item?.policyResult?.pass === true).length;
+    const failCount = totalChecked - passCount;
+
+    const violationCounts = new Map();
+    evaluated.forEach((item) => {
+        const violations = Array.isArray(item?.policyResult?.violations) ? item.policyResult.violations : [];
+        violations.forEach((violation) => {
+            const code = violation?.code || 'UNKNOWN';
+            violationCounts.set(code, (violationCounts.get(code) || 0) + 1);
+        });
+    });
+
+    const topViolations = Array.from(violationCounts.entries())
+        .map(([code, count]) => ({ code, count }))
+        .sort((a, b) => {
+            if (b.count !== a.count) return b.count - a.count;
+            return a.code.localeCompare(b.code);
+        });
+
+    return {
+        evaluated,
+        totalChecked,
+        passCount,
+        failCount,
+        topViolations
+    };
+}
+
+function getPolicyMode(policy) {
+    return policy?.mode === 'enforce' ? 'enforce' : 'audit';
+}
+
+function getOnViolationBehavior(policy) {
+    if (policy?.enforcement?.on_violation === 'warn') return 'warn';
+    return 'error';
+}
+
+function getViolationExitCode(policy) {
+    const configured = policy?.enforcement?.exit_code;
+    if (Number.isInteger(configured) && configured >= 1 && configured <= 255) {
+        return configured;
+    }
+    return 1;
+}
+
+function resolvePolicyEnforcement(policy, evaluation) {
+    const mode = getPolicyMode(policy);
+    const onViolation = getOnViolationBehavior(policy);
+    const failCount = evaluation?.failCount || 0;
+    const hasFailures = failCount > 0;
+
+    const shouldBlock = mode === 'enforce' && onViolation !== 'warn' && hasFailures;
+    const exitCode = shouldBlock ? getViolationExitCode(policy) : 0;
+
+    return {
+        mode,
+        onViolation,
+        hasFailures,
+        shouldBlock,
+        exitCode
+    };
+}
+
+module.exports = {
+    collectCandidatesFromAnalysis,
+    collectCandidatesFromRecommendationData,
+    buildPolicyRuntimeContext,
+    evaluatePolicyCandidates,
+    resolvePolicyEnforcement
+};

--- a/tests/policy-cli-enforcement.js
+++ b/tests/policy-cli-enforcement.js
@@ -1,0 +1,215 @@
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const PolicyEngine = require('../src/policy/policy-engine');
+const {
+    collectCandidatesFromAnalysis,
+    collectCandidatesFromRecommendationData,
+    buildPolicyRuntimeContext,
+    evaluatePolicyCandidates,
+    resolvePolicyEnforcement
+} = require('../src/policy/cli-policy');
+
+const BIN_PATH = path.resolve(__dirname, '..', 'bin', 'enhanced_cli.js');
+
+function runCli(args) {
+    return spawnSync(process.execPath, [BIN_PATH, ...args], {
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            NO_COLOR: '1'
+        }
+    });
+}
+
+function stripAnsi(text = '') {
+    return String(text).replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+function runAnalysisCandidateCollectionTests() {
+    const analysis = {
+        compatible: [
+            { model_identifier: 'qwen2.5-coder:7b-instruct-q4_k_m', name: 'Qwen Coding 7B' }
+        ],
+        marginal: [
+            { model_identifier: 'llama3.2:3b-instruct-q4_k_m', name: 'Llama 3.2 3B' }
+        ],
+        incompatible: [
+            { model_identifier: 'mistral:22b-instruct-q4_k_m', name: 'Should be ignored for check policy evaluation' }
+        ]
+    };
+
+    const candidates = collectCandidatesFromAnalysis(analysis);
+    assert.strictEqual(candidates.length, 2, 'analysis candidates should include only compatible and marginal models');
+    assert.ok(
+        candidates.some((model) => model.model_identifier === 'qwen2.5-coder:7b-instruct-q4_k_m'),
+        'should include compatible model'
+    );
+    assert.ok(
+        candidates.some((model) => model.model_identifier === 'llama3.2:3b-instruct-q4_k_m'),
+        'should include marginal model'
+    );
+    assert.ok(
+        !candidates.some((model) => model.model_identifier === 'mistral:22b-instruct-q4_k_m'),
+        'should exclude incompatible models from check policy evaluation'
+    );
+}
+
+function runRecommendationCandidateCollectionTests() {
+    const recommendationData = {
+        summary: {
+            by_category: {
+                coding: {
+                    name: 'Qwen Coder',
+                    identifier: 'qwen2.5-coder:14b-instruct-q4_k_m',
+                    size: '14B'
+                },
+                general: {
+                    name: 'Llama',
+                    identifier: 'llama3.2:3b',
+                    size: '3B'
+                }
+            },
+            best_overall: {
+                name: 'Qwen Coder',
+                identifier: 'qwen2.5-coder:14b-instruct-q4_k_m'
+            }
+        }
+    };
+
+    const candidates = collectCandidatesFromRecommendationData(recommendationData);
+    assert.strictEqual(candidates.length, 2, 'recommendation candidates should be deduplicated');
+
+    const codingCandidate = candidates.find((item) =>
+        item.model_identifier.includes('qwen2.5-coder:14b-instruct-q4_k_m')
+    );
+    assert.ok(codingCandidate, 'coding candidate should be present');
+    assert.strictEqual(codingCandidate.params_b, 14, 'params should be parsed from identifier');
+    assert.strictEqual(codingCandidate.quant, 'Q4_K_M', 'quantization should be parsed from identifier');
+}
+
+function runEnforcementResolutionTests() {
+    const candidates = [
+        { model_identifier: 'qwen2.5-coder:7b-instruct-q4_k_m' },
+        { model_identifier: 'llama3.2:3b-instruct-q4_k_m' }
+    ];
+
+    const enforcePolicy = {
+        mode: 'enforce',
+        rules: {
+            models: {
+                allow: ['qwen2.5-coder:*']
+            }
+        },
+        enforcement: {
+            exit_code: 7
+        }
+    };
+
+    const enforceEngine = new PolicyEngine(enforcePolicy);
+    const enforceEvaluation = evaluatePolicyCandidates(enforceEngine, candidates, {});
+    const enforceResolution = resolvePolicyEnforcement(enforcePolicy, enforceEvaluation);
+
+    assert.strictEqual(enforceEvaluation.totalChecked, 2);
+    assert.strictEqual(enforceEvaluation.passCount, 1);
+    assert.strictEqual(enforceEvaluation.failCount, 1);
+    assert.ok(
+        enforceEvaluation.topViolations.some((entry) => entry.code === 'MODEL_NOT_ALLOWED'),
+        'should expose top violation codes'
+    );
+    assert.strictEqual(enforceResolution.shouldBlock, true, 'enforce mode should block on violations');
+    assert.strictEqual(enforceResolution.exitCode, 7, 'configured exit code should be applied');
+
+    const auditPolicy = {
+        ...enforcePolicy,
+        mode: 'audit'
+    };
+    const auditResolution = resolvePolicyEnforcement(auditPolicy, enforceEvaluation);
+    assert.strictEqual(auditResolution.shouldBlock, false, 'audit mode should never block');
+    assert.strictEqual(auditResolution.exitCode, 0, 'audit mode should exit 0');
+
+    const warnPolicy = {
+        ...enforcePolicy,
+        enforcement: {
+            on_violation: 'warn',
+            exit_code: 9
+        }
+    };
+    const warnResolution = resolvePolicyEnforcement(warnPolicy, enforceEvaluation);
+    assert.strictEqual(warnResolution.shouldBlock, false, 'warn behavior should not block');
+    assert.strictEqual(warnResolution.exitCode, 0, 'warn behavior should exit 0');
+}
+
+function runContextBuilderTests() {
+    const hardware = {
+        summary: {
+            bestBackend: 'metal',
+            systemRAM: 32
+        },
+        memory: {
+            total: 32
+        }
+    };
+
+    const context = buildPolicyRuntimeContext({
+        hardware,
+        runtimeBackend: 'ollama'
+    });
+
+    assert.strictEqual(context.backend, 'metal');
+    assert.strictEqual(context.runtimeBackend, 'ollama');
+    assert.strictEqual(context.ramGB, 32);
+    assert.strictEqual(context.totalRamGB, 32);
+}
+
+function runHelpExamplesTests() {
+    const checkHelp = runCli(['check', '--help']);
+    assert.strictEqual(checkHelp.status, 0, stripAnsi(checkHelp.stderr || checkHelp.stdout));
+    const checkOutput = stripAnsi(`${checkHelp.stdout}\n${checkHelp.stderr}`);
+    assert.ok(
+        checkOutput.includes('Enterprise policy examples'),
+        'check help should include enterprise policy examples section'
+    );
+    assert.ok(
+        (checkOutput.match(/--policy/g) || []).length >= 3,
+        'check help should include three policy examples'
+    );
+
+    const recommendHelp = runCli(['recommend', '--help']);
+    assert.strictEqual(
+        recommendHelp.status,
+        0,
+        stripAnsi(recommendHelp.stderr || recommendHelp.stdout)
+    );
+    const recommendOutput = stripAnsi(`${recommendHelp.stdout}\n${recommendHelp.stderr}`);
+    assert.ok(
+        recommendOutput.includes('Enterprise policy examples'),
+        'recommend help should include enterprise policy examples section'
+    );
+    assert.ok(
+        (recommendOutput.match(/--policy/g) || []).length >= 3,
+        'recommend help should include three policy examples'
+    );
+}
+
+function runAll() {
+    runAnalysisCandidateCollectionTests();
+    runRecommendationCandidateCollectionTests();
+    runEnforcementResolutionTests();
+    runContextBuilderTests();
+    runHelpExamplesTests();
+    console.log('policy-cli-enforcement.js: OK');
+}
+
+if (require.main === module) {
+    try {
+        runAll();
+    } catch (error) {
+        console.error('policy-cli-enforcement.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+module.exports = { runAll };


### PR DESCRIPTION
## Summary
Implements enterprise policy enforcement for `check` and `recommend` with consistent evaluation, reporting, and exit behavior.

## What changed
- Added `--policy <file>` to:
  - `llm-checker check`
  - `llm-checker recommend`
- Added policy loading/validation and CLI policy summary output (total/pass/fail/top violations).
- Enforced audit/enforce behavior:
  - `audit` => always exit `0`
  - `enforce` + blocking violations => non-zero exit
  - supports configurable `enforcement.exit_code`
- Added enterprise policy examples to both command help outputs.
- Added reusable policy CLI helpers in `src/policy/cli-policy.js`.
- Added policy CLI tests in `tests/policy-cli-enforcement.js`.

## Scope confirmation for `check`
Policy enforcement in `check` evaluates **all compatible + marginal candidates discovered by analysis** (not only the top `--limit` displayed rows).

## Validation
- `npm run -s test:policy-cli`
- `node tests/policy-engine.test.js`
- `node tests/policy-commands.test.js`
- `node tests/runtime-specdec-tests.js`

All passed.

Closes #21.
