### PR TITLE
fix: unify hardware tier reporting across commands

### DIFF
--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -881,6 +881,11 @@ function formatGpuInventoryList(models = []) {
 
 // Helper function to get hardware tier for display
 function getHardwareTierForDisplay(hardware) {
+    const canonicalTier = hardware?.summary?.hardwareTier;
+    if (typeof canonicalTier === 'string' && canonicalTier.trim()) {
+        return canonicalTier.replace(/_/g, ' ').toUpperCase();
+    }
+
     const ram = hardware.memory.total;
     const cores = hardware.cpu.cores;
     const gpuModel = hardware.gpu?.model || '';
@@ -921,6 +926,21 @@ function getHardwareTierForDisplay(hardware) {
     }
     
     return tier;
+}
+
+function getBackendLabelForDisplay(hardware) {
+    const summary = hardware?.summary || {};
+
+    if (typeof summary.bestBackendLabel === 'string' && summary.bestBackendLabel.trim()) {
+        return summary.bestBackendLabel;
+    }
+
+    const backendName = summary.backendName || String(summary.bestBackend || 'cpu').toUpperCase();
+    if (summary.runtimeBackend && summary.runtimeBackend !== summary.bestBackend) {
+        return `${backendName} + ${summary.runtimeBackendName || summary.runtimeBackend} assist`;
+    }
+
+    return backendName;
 }
 
 function formatSpeed(speed) {
@@ -969,12 +989,13 @@ function displaySystemInfo(hardware, analysis) {
         `${chalk.cyan('Architecture:')} ${hardware.cpu.architecture}`,
         `${chalk.cyan('RAM:')} ${ramColor(hardware.memory.total + 'GB')}`,
         `${chalk.cyan('GPU:')} ${gpuColor(hardware.gpu.model || 'Not detected')}`,
+        `${chalk.cyan('Backend:')} ${chalk.white(getBackendLabelForDisplay(hardware))}`,
         `${chalk.cyan('VRAM:')} ${hardware.gpu.vram === 0 && hardware.gpu.model && hardware.gpu.model.toLowerCase().includes('apple') ? 'Unified Memory' : `${hardware.gpu.vram || 'N/A'}GB`}${hardware.gpu.dedicated ? chalk.green(' (Dedicated)') : chalk.hex('#FFA500')(' (Integrated)')}`,
         `${chalk.cyan('Dedicated GPUs:')} ${chalk.green(dedicatedList)}`,
         `${chalk.cyan('Integrated GPUs:')} ${chalk.hex('#FFA500')(integratedList)}`,
     ];
 
-    const tier = analysis.summary.hardwareTier?.replace('_', ' ').toUpperCase() || 'UNKNOWN';
+    const tier = analysis.summary.hardwareTier?.replace(/_/g, ' ').toUpperCase() || getHardwareTierForDisplay(hardware);
     const tierColor = tier.includes('HIGH') ? chalk.green : tier.includes('MEDIUM') ? chalk.yellow : chalk.red;
 
     lines.push(`${chalk.bold('Hardware Tier:')} ${tierColor.bold(tier)}`);
@@ -1758,6 +1779,7 @@ function displaySimplifiedSystemInfo(hardware) {
     console.log(`Memory: ${chalk.white(memInfo)}`);
     console.log(`GPU: ${chalk.white(gpuInfo)}`);
     console.log(`Architecture: ${chalk.white(hardware.cpu.architecture)}`);
+    console.log(`Backend: ${chalk.white(getBackendLabelForDisplay(hardware))}`);
     
     const tier = getHardwareTierForDisplay(hardware);
     const tierColor = tier.includes('HIGH') ? chalk.green : tier.includes('MEDIUM') ? chalk.yellow : chalk.red;
@@ -5058,7 +5080,7 @@ program
             console.log(`  ${detector.getHardwareDescription()}`);
             console.log(`  Tier: ${chalk.cyan(detector.getHardwareTier().replace('_', ' ').toUpperCase())}`);
             console.log(`  Max model size: ${chalk.green(detector.getMaxModelSize() + 'GB')}`);
-            console.log(`  Best backend: ${chalk.cyan(hardware.summary.bestBackend)}`);
+            console.log(`  Best backend: ${chalk.cyan(getBackendLabelForDisplay(hardware))}`);
             if (hardware.summary.runtimeBackend && hardware.summary.runtimeBackend !== hardware.summary.bestBackend) {
                 console.log(`  Runtime assist: ${chalk.green(hardware.summary.runtimeBackendName || hardware.summary.runtimeBackend)}`);
             }

--- a/src/hardware/unified-detector.js
+++ b/src/hardware/unified-detector.js
@@ -333,7 +333,36 @@ class UnifiedDetector {
             summary.effectiveMemory = Math.round(summary.systemRAM * 0.7);
         }
 
+        summary.hardwareTier = this.classifyHardwareTierFromSummary(summary);
+        summary.bestBackendLabel = this.getBestBackendLabel(summary);
+
         return summary;
+    }
+
+    classifyHardwareTierFromSummary(summary = {}) {
+        const effectiveMem = Number(summary.effectiveMemory) || 0;
+        const speed = Number(summary.speedCoefficient) || 0;
+
+        if (effectiveMem >= 80 && speed >= 300) return 'ultra_high';      // H100, MI300
+        if (effectiveMem >= 48 && speed >= 200) return 'very_high';       // 2x3090, 4090
+        if (effectiveMem >= 24 && speed >= 150) return 'high';            // 3090, 4090, M2 Max
+        if (effectiveMem >= 16 && speed >= 100) return 'medium_high';     // 4080, 3080, M3 Pro
+        if (effectiveMem >= 12 && speed >= 80) return 'medium';           // 3060, 4060 Ti
+        if (effectiveMem >= 8 && speed >= 50) return 'medium_low';        // 3060, M2
+        if (effectiveMem >= 6 && speed >= 30) return 'low';               // GTX 1660, iGPU
+        return 'ultra_low';                                                // CPU only
+    }
+
+    getBestBackendLabel(summary = {}) {
+        const backendName = summary.backendName || String(summary.bestBackend || 'cpu').toUpperCase();
+        if (
+            summary.hasRuntimeAssist &&
+            summary.runtimeBackend &&
+            summary.runtimeBackend !== summary.bestBackend
+        ) {
+            return `${backendName} + ${summary.runtimeBackendName || summary.runtimeBackend} assist`;
+        }
+        return backendName;
     }
 
     summarizeGPUInventory(gpus = []) {
@@ -844,19 +873,7 @@ class UnifiedDetector {
         const result = this.cache;
         if (!result) return 'unknown';
 
-        const summary = result.summary;
-        const effectiveMem = summary.effectiveMemory;
-        const speed = summary.speedCoefficient;
-
-        // Tier based on effective memory and speed
-        if (effectiveMem >= 80 && speed >= 300) return 'ultra_high';      // H100, MI300
-        if (effectiveMem >= 48 && speed >= 200) return 'very_high';       // 2x3090, 4090
-        if (effectiveMem >= 24 && speed >= 150) return 'high';            // 3090, 4090, M2 Max
-        if (effectiveMem >= 16 && speed >= 100) return 'medium_high';     // 4080, 3080, M3 Pro
-        if (effectiveMem >= 12 && speed >= 80) return 'medium';           // 3060, 4060 Ti
-        if (effectiveMem >= 8 && speed >= 50) return 'medium_low';        // 3060, M2
-        if (effectiveMem >= 6 && speed >= 30) return 'low';               // GTX 1660, iGPU
-        return 'ultra_low';                                                // CPU only
+        return result.summary?.hardwareTier || this.classifyHardwareTierFromSummary(result.summary);
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -1345,7 +1345,25 @@ class LLMChecker {
     }
 
     getHardwareTier(hardware) {
+        const canonicalTier = hardware?.summary?.hardwareTier;
+        if (typeof canonicalTier === 'string' && canonicalTier.trim()) {
+            return canonicalTier.trim().toLowerCase().replace(/\s+/g, '_');
+        }
         return this.calculateHardwareScore(hardware).tier;
+    }
+
+    getHardwareTierBucket(hardware) {
+        const tier = this.getHardwareTier(hardware);
+        switch (tier) {
+            case 'very_high':
+                return 'ultra_high';
+            case 'medium_high':
+                return 'high';
+            case 'medium_low':
+                return 'low';
+            default:
+                return tier;
+        }
     }
 
     calculateHardwareScore(hardware) {
@@ -2003,7 +2021,7 @@ class LLMChecker {
             score -= 15;
         }
 
-        const hardwareTier = this.getHardwareTier(hardware);
+        const hardwareTier = this.getHardwareTierBucket(hardware);
         switch (hardwareTier) {
             case 'ultra_high':
                 score += 15;

--- a/src/models/deterministic-selector.js
+++ b/src/models/deterministic-selector.js
@@ -2141,6 +2141,10 @@ class DeterministicModelSelector {
 
     mapHardwareTier(hardware = {}) {
         const summary = hardware?.summary || {};
+        const canonicalTier = summary.hardwareTier || summary.hardware_tier;
+        if (typeof canonicalTier === 'string' && canonicalTier.trim()) {
+            return canonicalTier.trim().toLowerCase().replace(/\s+/g, '_');
+        }
         const effectiveMemory = Number(summary.effectiveMemory);
         const speedCoefficient = Number(summary.speedCoefficient);
         if (Number.isFinite(effectiveMemory) && effectiveMemory > 0 && Number.isFinite(speedCoefficient)) {

--- a/tests/hardware-tier-consistency.test.js
+++ b/tests/hardware-tier-consistency.test.js
@@ -1,0 +1,109 @@
+const assert = require('assert');
+
+const UnifiedDetector = require('../src/hardware/unified-detector');
+const LLMChecker = require('../src/index');
+const DeterministicModelSelector = require('../src/models/deterministic-selector');
+
+function buildWindowsIntegratedAssistResult() {
+    return {
+        platform: 'win32',
+        cpu: { brand: 'AMD Ryzen AI 9 HX 370 w/ Radeon 890M', speedCoefficient: 55 },
+        primary: { type: 'cpu', name: 'CPU', info: { speedCoefficient: 55 } },
+        systemGpu: {
+            available: true,
+            hasDedicated: false,
+            gpus: [
+                {
+                    name: 'AMD Radeon(TM) 890M Graphics',
+                    type: 'integrated',
+                    memory: { total: 48 }
+                }
+            ],
+            totalVRAM: 0,
+            isMultiGPU: false
+        }
+    };
+}
+
+function buildConflictingHardwareProfile() {
+    return {
+        cpu: {
+            brand: 'AMD Ryzen AI 9 HX 370 w/ Radeon 890M',
+            architecture: 'x86_64',
+            cores: 24,
+            physicalCores: 12,
+            speed: 2.0
+        },
+        memory: { total: 48 },
+        gpu: {
+            model: 'AMD Radeon(TM) 890M Graphics',
+            vendor: 'AMD',
+            vram: 0,
+            dedicated: false
+        },
+        os: { platform: 'win32' },
+        summary: {
+            bestBackend: 'cpu',
+            backendName: 'CPU',
+            runtimeBackend: 'vulkan',
+            runtimeBackendName: 'Vulkan',
+            bestBackendLabel: 'CPU + Vulkan assist',
+            hardwareTier: 'medium_low',
+            effectiveMemory: 34,
+            speedCoefficient: 55,
+            hasIntegratedGPU: true,
+            hasDedicatedGPU: false
+        }
+    };
+}
+
+function testSummaryExposesCanonicalTierAndBackendLabel() {
+    const detector = new UnifiedDetector();
+    const summary = detector.buildSummary(buildWindowsIntegratedAssistResult());
+
+    assert.strictEqual(summary.runtimeBackend, 'vulkan');
+    assert.strictEqual(summary.hasRuntimeAssist, true);
+    assert.strictEqual(summary.bestBackendLabel, 'CPU + Vulkan assist');
+    assert.strictEqual(summary.hardwareTier, 'medium_low');
+}
+
+function testLlmCheckerPrefersCanonicalHardwareTier() {
+    const checker = new LLMChecker({ verbose: false });
+    const hardware = buildConflictingHardwareProfile();
+
+    assert.strictEqual(
+        checker.getHardwareTier(hardware),
+        'medium_low',
+        'LLMChecker should honor the unified detector tier before optimistic heuristics'
+    );
+}
+
+function testDeterministicSelectorPrefersCanonicalHardwareTier() {
+    const selector = new DeterministicModelSelector();
+    const hardware = buildConflictingHardwareProfile();
+
+    assert.strictEqual(
+        selector.mapHardwareTier(hardware),
+        'medium_low',
+        'Deterministic selector should honor the unified detector tier when it is available'
+    );
+}
+
+function run() {
+    testSummaryExposesCanonicalTierAndBackendLabel();
+    testLlmCheckerPrefersCanonicalHardwareTier();
+    testDeterministicSelectorPrefersCanonicalHardwareTier();
+    console.log('hardware-tier-consistency.test.js: OK');
+}
+
+if (require.main === module) {
+    try {
+        run();
+    } catch (error) {
+        console.error('hardware-tier-consistency.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+module.exports = { run };

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -11,6 +11,7 @@ const TESTS = [
     { name: 'CUDA Jetson detection', file: 'cuda-jetson-detection.test.js', category: 'Hardware' },
     { name: 'Hardware simulation scoring', file: 'hardware-simulation-tests.js', category: 'Hardware' },
     { name: 'Hardware detector regression', file: 'hardware-detector-regression.js', category: 'Hardware' },
+    { name: 'Hardware tier consistency', file: 'hardware-tier-consistency.test.js', category: 'Hardware' },
     { name: 'ROCm VRAM parsing regression', file: 'rocm-vram-parsing.test.js', category: 'Hardware' },
     { name: 'CPU detector Windows fallback', file: 'cpu-detector-windows-fallback.test.js', category: 'Hardware' },
     { name: 'Termux platform support', file: 'termux-platform-support.test.js', category: 'Hardware' },


### PR DESCRIPTION
## Summary
- unify `hw-detect` and `check` around the canonical hardware tier from the unified detector
- surface assisted execution as a combined backend label such as `CPU + Vulkan assist`
- keep recommendation routing aligned with the same canonical detector summary
- add a regression test covering the issue #71 tier mismatch path

## Validation
- `npm test`
- `33/33` passing

## Notes
- This follows issue #71 but intentionally does not close it yet; the reporter still needs to confirm the fix on the affected Windows setup.
