### PR TITLE
Fix ROCm memory parsing and RTX 5060 recommendations

### DIFF
--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -983,6 +983,12 @@ function displaySystemInfo(hardware, analysis) {
     const gpuColor = hardware.gpu.dedicated ? chalk.green : chalk.hex('#FFA500');
     const integratedList = formatGpuInventoryList(hardware.gpu.integratedGpuModels || hardware.summary?.integratedGpuModels);
     const dedicatedList = formatGpuInventoryList(hardware.gpu.dedicatedGpuModels || hardware.summary?.dedicatedGpuModels);
+    const integratedSharedMemory = hardware.gpu.sharedMemory || hardware.summary?.integratedSharedMemory || 0;
+    const vramDisplay = !hardware.gpu.dedicated && integratedSharedMemory > 0
+        ? `${integratedSharedMemory}GB shared`
+        : (hardware.gpu.vram === 0 && hardware.gpu.model && hardware.gpu.model.toLowerCase().includes('apple')
+            ? 'Unified Memory'
+            : `${hardware.gpu.vram || 'N/A'}GB`);
 
     const lines = [
         `${chalk.cyan('CPU:')} ${cpuColor(hardware.cpu.brand)} ${chalk.gray(`(${hardware.cpu.cores} cores, ${hardware.cpu.speed}GHz)`)}`,
@@ -990,7 +996,7 @@ function displaySystemInfo(hardware, analysis) {
         `${chalk.cyan('RAM:')} ${ramColor(hardware.memory.total + 'GB')}`,
         `${chalk.cyan('GPU:')} ${gpuColor(hardware.gpu.model || 'Not detected')}`,
         `${chalk.cyan('Backend:')} ${chalk.white(getBackendLabelForDisplay(hardware))}`,
-        `${chalk.cyan('VRAM:')} ${hardware.gpu.vram === 0 && hardware.gpu.model && hardware.gpu.model.toLowerCase().includes('apple') ? 'Unified Memory' : `${hardware.gpu.vram || 'N/A'}GB`}${hardware.gpu.dedicated ? chalk.green(' (Dedicated)') : chalk.hex('#FFA500')(' (Integrated)')}`,
+        `${chalk.cyan('VRAM:')} ${vramDisplay}${hardware.gpu.dedicated ? chalk.green(' (Dedicated)') : chalk.hex('#FFA500')(' (Integrated)')}`,
         `${chalk.cyan('Dedicated GPUs:')} ${chalk.green(dedicatedList)}`,
         `${chalk.cyan('Integrated GPUs:')} ${chalk.hex('#FFA500')(integratedList)}`,
     ];
@@ -5128,9 +5134,23 @@ program
 
                 if (backend === 'rocm' && info.info) {
                     console.log(`  ROCm: ${info.info.rocmVersion}`);
-                    console.log(`  Total VRAM: ${info.info.totalVRAM}GB`);
+                    const integratedOnly = (info.info.gpus || []).length > 0 &&
+                        (info.info.gpus || []).every((gpu) => gpu.type === 'integrated');
+                    if (integratedOnly) {
+                        console.log(`  Total dedicated aperture: ${info.info.totalVRAM || 0}GB`);
+                        console.log(`  Total shared memory: ${info.info.totalSharedMemory || 0}GB`);
+                    } else {
+                        console.log(`  Total VRAM: ${info.info.totalVRAM}GB`);
+                    }
                     for (const gpu of info.info.gpus) {
-                        console.log(`  ${gpu.name}: ${gpu.memory.total}GB`);
+                        if (gpu.type === 'integrated') {
+                            const dedicated = gpu.memory?.dedicated || 0;
+                            const shared = gpu.memory?.shared || gpu.memory?.total || 0;
+                            const dedicatedLabel = dedicated > 0 ? `, ${dedicated}GB aperture` : '';
+                            console.log(`  ${gpu.name}: ${shared}GB shared${dedicatedLabel} (Integrated)`);
+                        } else {
+                            console.log(`  ${gpu.name}: ${gpu.memory.total}GB`);
+                        }
                     }
                 }
 

--- a/src/ai/multi-objective-selector.js
+++ b/src/ai/multi-objective-selector.js
@@ -111,10 +111,45 @@ class MultiObjectiveSelector {
             return false; // Model too large for this tier regardless of RAM
         }
         
-        // Memory check with tier-appropriate safety margin
-        const availableMemory = hardware.memory.total * limits.availableMemoryRatio;
+        // Memory check with tier-appropriate safety margin. Dedicated GPUs can
+        // run quantized models primarily from VRAM with limited RAM offload, so
+        // using only system RAM underestimates mid-range cards such as RTX 5060.
+        const availableMemory = this.getAvailableModelMemoryGB(hardware, limits.availableMemoryRatio);
         
         return totalMemoryNeeded <= availableMemory;
+    }
+
+    getAvailableModelMemoryGB(hardware, fallbackRatio = 0.7) {
+        const ramGB = Number(hardware?.memory?.total ?? hardware?.memory?.totalGB ?? 0) || 0;
+        const vramGB = Number(
+            hardware?.gpu?.vram ??
+            hardware?.gpu?.vramGB ??
+            hardware?.summary?.totalVRAM ??
+            0
+        ) || 0;
+        const hasIntegratedGPU = typeof hardware?.summary?.hasIntegratedGPU === 'boolean'
+            ? hardware.summary.hasIntegratedGPU
+            : false;
+        const hasDedicatedGPU = typeof hardware?.summary?.hasDedicatedGPU === 'boolean'
+            ? hardware.summary.hasDedicatedGPU
+            : Boolean(hardware?.gpu?.dedicated || (vramGB > 0 && !hasIntegratedGPU));
+
+        if (hasDedicatedGPU && vramGB > 0) {
+            const pcSpecs = this.getPCGPUSpecs(hardware, vramGB, ramGB);
+            const vramBudget = vramGB * (pcSpecs.memoryEfficiency || 0.85);
+            const offloadBudget = Math.min(
+                pcSpecs.offloadCapacity || 0,
+                Math.max(0, ramGB * 0.5)
+            );
+            return Math.max(vramBudget, vramBudget + offloadBudget);
+        }
+
+        const sharedMemory = Number(hardware?.summary?.integratedSharedMemory || hardware?.gpu?.sharedMemory || 0);
+        if (sharedMemory > 0 && !hasDedicatedGPU) {
+            return sharedMemory * Math.max(fallbackRatio, 0.85);
+        }
+
+        return ramGB * fallbackRatio;
     }
 
     /**
@@ -274,8 +309,10 @@ class MultiObjectiveSelector {
                 return num / (1024 ** 3); // Convert bytes to GB
             } else if (num >= 0.1 && num <= 100) {
                 // Small numbers (0.1-100) are likely billion parameters - convert to file size
-                // Rough estimate: 1B params ≈ 2GB in Q4 quantization
-                return Math.max(0.5, num * 2);
+                // Static catalog `B` values are parameter counts. Default check
+                // recommendations target quantized local inference, where Q4
+                // artifacts are roughly 0.6-0.7GB per billion parameters.
+                return Math.max(0.5, Math.round(num * 0.65 * 10) / 10);
             } else {
                 // Fallback for edge cases
                 return Math.max(0.5, num);
@@ -329,7 +366,7 @@ class MultiObjectiveSelector {
         const clamp = (x, a = 0, b = 1) => Math.max(a, Math.min(b, x));
         
         const ramGB = hardware.memory.total || 0;
-        const vramGB = hardware.gpu?.vram || 0;
+        const vramGB = hardware.gpu?.vram || hardware.gpu?.vramGB || hardware.summary?.totalVRAM || 0;
         const cpuModel = hardware.cpu?.brand || hardware.cpu?.model || '';
         const gpuModel = hardware.gpu?.model || '';
         const architecture = hardware.cpu?.architecture || hardware.cpu?.brand || '';
@@ -406,6 +443,7 @@ class MultiObjectiveSelector {
         else if (gpu.includes('rtx 4090')) memBandwidthGBs = 1008;
         else if (gpu.includes('rtx 4080')) memBandwidthGBs = 716;
         else if (gpu.includes('rtx 4070')) memBandwidthGBs = 448;
+        else if (gpu.includes('rtx 5060')) memBandwidthGBs = 336;
         else if (gpu.includes('iris xe')) memBandwidthGBs = 68;
         
         const mem_bw = clamp(memBandwidthGBs / 500);  // Match main algorithm
@@ -419,6 +457,7 @@ class MultiObjectiveSelector {
         else if (gpu.includes('m4')) compute = clamp(15 / 80);
         else if (gpu.includes('rtx 4090')) compute = clamp(165 / 80);
         else if (gpu.includes('rtx 4080')) compute = clamp(121 / 80);
+        else if (gpu.includes('rtx 5060')) compute = clamp(38 / 80);
         else if (gpu.includes('iris xe')) compute = 0.02;
         else {
             // CPU fallback
@@ -464,7 +503,7 @@ class MultiObjectiveSelector {
         }
         
         // Special flagship GPU detection by model name
-        if (gpuModel.toLowerCase().includes('rtx 50') || 
+        if (gpuModel.toLowerCase().includes('rtx 5090') ||
             gpuModel.toLowerCase().includes('gb10') ||
             gpuModel.toLowerCase().includes('grace blackwell') ||
             gpuModel.toLowerCase().includes('dgx spark') ||
@@ -472,6 +511,10 @@ class MultiObjectiveSelector {
             gpuModel.toLowerCase().includes('h100') || 
             gpuModel.toLowerCase().includes('a100')) {
             tier = 'flagship';
+        } else if (gpuModel.toLowerCase().includes('rtx 5080')) {
+            tier = bumpTier(tier, tier === 'ultra_high' || tier === 'flagship' ? 0 : +1);
+        } else if (gpuModel.toLowerCase().includes('rtx 5070') && !gpuModel.toLowerCase().includes('rtx 5070 ti')) {
+            tier = bumpTier(tier, tier === 'high' || tier === 'ultra_high' || tier === 'flagship' ? 0 : +1);
         }
         
         return tier;
@@ -624,10 +667,13 @@ class MultiObjectiveSelector {
                 specs.offloadCapacity = Math.min(ramGB * 0.6, 32);
                 specs.memoryEfficiency = 0.96;
                 specs.backendOptimization = 1.25;
-            } else if (gpu.includes('rtx 50')) {
-                // RTX 50xx series - flagship tier with massive VRAM + excellent offload
+            } else if (gpu.includes('rtx 5090') || gpu.includes('rtx 5080') || gpu.includes('rtx 5070')) {
+                // Upper RTX 50xx cards have excellent offload behavior.
                 specs.offloadCapacity = Math.min(ramGB * 0.5, 24);
                 specs.memoryEfficiency = 0.95;
+            } else if (gpu.includes('rtx 5060')) {
+                specs.offloadCapacity = Math.min(ramGB * 0.35, 12);
+                specs.memoryEfficiency = 0.90;
             } else if (gpu.includes('rtx 40')) {
                 specs.offloadCapacity = Math.min(ramGB * 0.35, 16);
                 specs.memoryEfficiency = 0.90;
@@ -751,7 +797,7 @@ class MultiObjectiveSelector {
         const gpuModel = hardware.gpu?.model || '';
         const cores = hardware.cpu?.physicalCores || hardware.cpu?.cores || 1;
         const baseSpeed = hardware.cpu?.speed || 2.0;
-        const vramGB = hardware.gpu?.vram || 0;
+        const vramGB = hardware.gpu?.vram || hardware.gpu?.vramGB || hardware.summary?.totalVRAM || 0;
         const hasIntegratedGPU = typeof hardware.summary?.hasIntegratedGPU === 'boolean'
             ? hardware.summary.hasIntegratedGPU
             : false;

--- a/src/hardware/backends/rocm-detector.js
+++ b/src/hardware/backends/rocm-detector.js
@@ -7,6 +7,7 @@
 
 const { execSync } = require('child_process');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 class ROCmDetector {
@@ -20,6 +21,9 @@ class ROCmDetector {
     static AMD_DEVICE_IDS = {
         // RDNA 4 / Radeon AI PRO
         '7551': { name: 'AMD Radeon AI PRO R9700', vram: 32 },
+        '7590': { name: 'AMD Radeon RX 9060 XT', vram: 16 },
+        '7580': { name: 'AMD Radeon RX 9070 XT', vram: 16 },
+        '7581': { name: 'AMD Radeon RX 9070', vram: 16 },
         // RDNA 3 (RX 7000 series)
         '744c': { name: 'AMD Radeon RX 7900 XTX', vram: 24 },
         '7448': { name: 'AMD Radeon RX 7900 XT', vram: 20 },
@@ -170,6 +174,7 @@ class ROCmDetector {
             gpus: [],
             rocmVersion: null,
             totalVRAM: 0,
+            totalSharedMemory: 0,
             backend: 'rocm',
             isMultiGPU: false,
             speedCoefficient: 0
@@ -235,12 +240,7 @@ class ROCmDetector {
                 timeout: 10000
             });
 
-            // Parse GPU names
-            const gpuNames = [];
-            const nameMatches = gpuList.matchAll(/GPU\[(\d+)\].*?:\s*(.+)/g);
-            for (const match of nameMatches) {
-                gpuNames[parseInt(match[1])] = match[2].trim();
-            }
+            const gpuNames = this.parseRocmSmiProductNames(gpuList);
 
             // Get VRAM info
             const memInfo = execSync('rocm-smi --showmeminfo vram', {
@@ -248,21 +248,7 @@ class ROCmDetector {
                 timeout: 10000
             });
 
-            // Parse memory info. Newer rocm-smi reports bytes "(B)" while some
-            // systems expose MiB; normalize to GB safely.
-            const gpuMemory = {};
-            const memLines = String(memInfo || '').split('\n');
-            for (const line of memLines) {
-                const lineMatch = line.match(/GPU\[(\d+)\].*?Total.*?Memory\s*(?:\(([^)]+)\))?\s*:\s*(\d+)/i);
-                if (!lineMatch) continue;
-
-                const idx = parseInt(lineMatch[1], 10);
-                const unitHint = lineMatch[2] || '';
-                const rawValue = parseInt(lineMatch[3], 10);
-
-                if (!Number.isFinite(rawValue) || rawValue <= 0) continue;
-                gpuMemory[idx] = this.normalizeRocmMemoryToGB(rawValue, unitHint);
-            }
+            const gpuMemory = this.parseRocmSmiMemoryInfo(memInfo);
 
             // Get temperature and utilization
             let temps = {};
@@ -294,22 +280,27 @@ class ROCmDetector {
             for (let i = 0; i < numGPUs; i++) {
                 const name = gpuNames[i] || `AMD GPU ${i}`;
                 const detectedVram = gpuMemory[i];
-                let vram = Number.isFinite(detectedVram) && detectedVram > 0
-                    ? this.applyIntegratedVramHeuristic(name, detectedVram)
-                    : this.estimateVRAMFromModel(name);
+                const memoryProfile = this.resolveGpuMemoryProfile(name, detectedVram);
+                const vram = memoryProfile.total;
 
                 if (!Number.isFinite(vram) || vram <= 0) {
-                    vram = 8;
+                    continue;
                 }
 
                 const gpu = {
                     index: i,
                     name: name,
+                    type: memoryProfile.type,
                     memory: {
                         total: vram,
                         free: vram,
-                        used: 0
+                        used: 0,
+                        dedicated: memoryProfile.dedicated,
+                        shared: memoryProfile.shared
                     },
+                    dedicatedMemory: memoryProfile.dedicated,
+                    sharedMemory: memoryProfile.shared,
+                    unifiedMemory: memoryProfile.type === 'integrated' ? memoryProfile.shared : 0,
                     temperature: temps[i] || 0,
                     utilization: utils[i] || 0,
                     capabilities: this.getGPUCapabilities(name),
@@ -317,13 +308,100 @@ class ROCmDetector {
                 };
 
                 result.gpus.push(gpu);
-                result.totalVRAM += vram;
+                result.totalVRAM += memoryProfile.type === 'integrated' ? memoryProfile.dedicated : vram;
+                result.totalSharedMemory += memoryProfile.type === 'integrated' ? memoryProfile.shared : 0;
             }
 
             return result.gpus.length > 0;
         } catch (e) {
             return false;
         }
+    }
+
+    parseRocmSmiProductNames(productOutput) {
+        const names = [];
+        const gfxFallbacks = {};
+        const deviceFallbacks = {};
+        const lines = String(productOutput || '').split('\n');
+
+        for (const line of lines) {
+            let match = line.match(/GPU\[(\d+)\]\s*:\s*Card Series\s*:\s*(.+)$/i);
+            if (match) {
+                names[parseInt(match[1], 10)] = this.normalizeRocmGpuName(match[2]);
+                continue;
+            }
+
+            match = line.match(/GPU\[(\d+)\]\s*:\s*Card Model\s*:\s*(?:0x)?([0-9a-f]{4})/i);
+            if (match) {
+                const deviceInfo = ROCmDetector.AMD_DEVICE_IDS[String(match[2]).toLowerCase()];
+                if (deviceInfo?.name) {
+                    deviceFallbacks[parseInt(match[1], 10)] = deviceInfo.name;
+                }
+                continue;
+            }
+
+            match = line.match(/GPU\[(\d+)\]\s*:\s*GFX Version\s*:\s*(gfx\d+)/i);
+            if (match) {
+                gfxFallbacks[parseInt(match[1], 10)] = match[2].toLowerCase();
+            }
+        }
+
+        const maxIndex = Math.max(
+            names.length - 1,
+            ...Object.keys(gfxFallbacks).map(Number),
+            ...Object.keys(deviceFallbacks).map(Number),
+            -1
+        );
+
+        for (let index = 0; index <= maxIndex; index += 1) {
+            if (!names[index]) {
+                names[index] = deviceFallbacks[index] || this.resolveGfxDisplayName(gfxFallbacks[index]);
+            }
+        }
+
+        return names;
+    }
+
+    normalizeRocmGpuName(value) {
+        return String(value || '')
+            .replace(/^GFX Version\s*:\s*/i, '')
+            .replace(/\s+/g, ' ')
+            .trim();
+    }
+
+    resolveGfxDisplayName(gfxVersion) {
+        const gfx = String(gfxVersion || '').toLowerCase().trim();
+        if (!gfx) return null;
+
+        if (gfx === 'gfx1151') return 'AMD Radeon 8060S (gfx1151)';
+        if (gfx === 'gfx1150' || gfx === 'gfx1152') return `AMD Strix Halo GPU (${gfx})`;
+        if (gfx === 'gfx1103') return 'AMD Radeon 780M (gfx1103)';
+        if (gfx === 'gfx1200' || gfx === 'gfx1201') return `AMD RDNA 4 GPU (${gfx})`;
+
+        return gfx;
+    }
+
+    parseRocmSmiMemoryInfo(memInfo) {
+        const gpuMemory = {};
+        const memLines = String(memInfo || '').split('\n');
+
+        for (const line of memLines) {
+            if (/Total\s+Used\s+Memory/i.test(line)) continue;
+
+            const lineMatch =
+                line.match(/GPU\[(\d+)\]\s*:\s*VRAM\s+Total\s+Memory\s*(?:\(([^)]+)\))?\s*:\s*(\d+)/i) ||
+                line.match(/GPU\[(\d+)\].*?\bTotal\s+Memory\s*(?:\(([^)]+)\))?\s*:\s*(\d+)/i);
+            if (!lineMatch) continue;
+
+            const idx = parseInt(lineMatch[1], 10);
+            const unitHint = lineMatch[2] || '';
+            const rawValue = parseInt(lineMatch[3], 10);
+
+            if (!Number.isFinite(rawValue) || rawValue <= 0) continue;
+            gpuMemory[idx] = this.normalizeRocmMemoryToGB(rawValue, unitHint);
+        }
+
+        return gpuMemory;
     }
 
     /**
@@ -464,24 +542,23 @@ class ROCmDetector {
     }
 
     getRocmAgentDisplayName(agent = {}) {
-        const marketingName = String(agent.marketingName || '').trim();
-        if (marketingName && marketingName.toLowerCase() !== 'n/a') {
-            return marketingName;
-        }
+        const candidates = [
+            agent.marketingName,
+            agent.name,
+            ...(Array.isArray(agent.aliases) ? agent.aliases : [])
+        ]
+            .map((item) => String(item || '').trim())
+            .filter(Boolean)
+            .filter((item) => item.toLowerCase() !== 'n/a');
 
-        const name = String(agent.name || '').trim();
-        if (name) {
-            return name;
-        }
+        const descriptive = candidates.find((item) => !this.isGenericRocmName(item) && !/^gfx\d+$/i.test(item));
+        if (descriptive) return descriptive;
 
-        if (Array.isArray(agent.aliases)) {
-            const fallback = agent.aliases
-                .map((item) => String(item || '').trim())
-                .find(Boolean);
-            if (fallback) {
-                return fallback;
-            }
-        }
+        const gfx = candidates.find((item) => /^gfx\d+$/i.test(item) || /--gfx\d+/i.test(item));
+        if (gfx) return this.resolveGfxDisplayName((gfx.match(/gfx\d+/i) || [gfx])[0]) || gfx;
+
+        const fallback = candidates.find((item) => !this.isGenericRocmName(item));
+        if (fallback) return fallback;
 
         return 'AMD GPU';
     }
@@ -490,6 +567,17 @@ class ROCmDetector {
         const uuid = String(agent.uuid || '').trim().toLowerCase();
         if (uuid) {
             return `uuid:${uuid}`;
+        }
+
+        const probe = [
+            resolvedName,
+            agent.marketingName,
+            agent.name,
+            ...(Array.isArray(agent.aliases) ? agent.aliases : [])
+        ].join(' ').toLowerCase();
+        const gfxMatch = probe.match(/\bgfx\d{3,4}\b/);
+        if (gfxMatch) {
+            return `gfx:${gfxMatch[0]}`;
         }
 
         const normalizedName = String(resolvedName || '')
@@ -504,13 +592,26 @@ class ROCmDetector {
         return `agent:${agent.index || 0}`;
     }
 
+    isGenericRocmName(name = '') {
+        const lower = String(name || '').toLowerCase().replace(/\s+/g, ' ').trim();
+        return lower === 'amd' ||
+            lower === 'advanced micro devices' ||
+            lower === 'advanced micro devices, inc.' ||
+            lower === 'advanced micro devices, inc. [amd/ati]' ||
+            lower.startsWith('amdgcn-amd-amdhsa--');
+    }
+
     isLikelyIntegratedGPU(name = '') {
         const nameLower = String(name || '').toLowerCase();
         if (!nameLower) return false;
 
         if (nameLower.includes('integrated') || nameLower.includes('apu')) return true;
         if (nameLower.includes('radeon graphics') && !nameLower.includes('rx')) return true;
+        if (nameLower.includes('radeon 8060s') || nameLower.includes('radeon 890m') ||
+            nameLower.includes('radeon 880m') || nameLower.includes('radeon 780m') ||
+            nameLower.includes('radeon 680m')) return true;
         if (nameLower.includes('gfx1150') || nameLower.includes('gfx1151') || nameLower.includes('gfx1152')) return true;
+        if (nameLower.includes('gfx1103') || nameLower.includes('gfx1035')) return true;
 
         return false;
     }
@@ -537,6 +638,91 @@ class ROCmDetector {
         return 8;
     }
 
+    resolveGpuMemoryProfile(name, detectedVramGB) {
+        const detected = Number(detectedVramGB);
+        const detectedVram = Number.isFinite(detected) && detected > 0 ? detected : 0;
+
+        if (!this.isLikelyIntegratedGPU(name)) {
+            const total = detectedVram || this.estimateVRAMFromModel(name) || 8;
+            return {
+                type: 'dedicated',
+                total,
+                dedicated: total,
+                shared: 0
+            };
+        }
+
+        const sysfsProfile = this.getIntegratedMemoryProfile();
+        const estimatedShared = this.applyIntegratedVramHeuristic(
+            name,
+            detectedVram || this.estimateVRAMFromModel(name)
+        );
+        const dedicated = sysfsProfile.dedicated || detectedVram || 0;
+        const shared = Math.max(sysfsProfile.shared || 0, estimatedShared || 0, dedicated);
+        const total = shared || dedicated || this.estimateVRAMFromModel(name) || 8;
+
+        return {
+            type: 'integrated',
+            total,
+            dedicated,
+            shared: total
+        };
+    }
+
+    getIntegratedMemoryProfile() {
+        const dedicatedValues = this.readAmdSysfsMemoryValues('mem_info_vram_total');
+        const sharedValues = this.readAmdSysfsMemoryValues('mem_info_gtt_total');
+        const totalSystemGB = Math.max(1, Math.round(os.totalmem() / (1024 ** 3)));
+        const rawShared = sharedValues.length > 0 ? Math.max(...sharedValues) : 0;
+
+        return {
+            dedicated: dedicatedValues.length > 0 ? Math.max(...dedicatedValues) : 0,
+            shared: rawShared > 0 ? Math.min(rawShared, Math.round(totalSystemGB * 0.95)) : 0
+        };
+    }
+
+    readAmdSysfsMemoryValues(fileName) {
+        const values = [];
+        const candidatePaths = [];
+
+        try {
+            const moduleRoot = '/sys/module/amdgpu/drivers/pci:amdgpu';
+            for (const entry of fs.readdirSync(moduleRoot)) {
+                candidatePaths.push(path.join(moduleRoot, entry, fileName));
+            }
+        } catch (e) {
+            // sysfs may be unavailable or restricted
+        }
+
+        try {
+            const drmRoot = '/sys/class/drm';
+            for (const entry of fs.readdirSync(drmRoot)) {
+                if (!/^card\d+$/.test(entry)) continue;
+                candidatePaths.push(path.join(drmRoot, entry, 'device', fileName));
+            }
+        } catch (e) {
+            // sysfs may be unavailable or restricted
+        }
+
+        const seen = new Set();
+        for (const candidatePath of candidatePaths) {
+            if (seen.has(candidatePath)) continue;
+            seen.add(candidatePath);
+
+            try {
+                const raw = parseInt(fs.readFileSync(candidatePath, 'utf8').trim(), 10);
+                const gb = this.normalizeRocmMemoryToGB(raw, 'B');
+                if (Number.isFinite(gb) && gb > 0) {
+                    values.push(gb);
+                }
+            } catch (e) {
+                continue;
+            }
+        }
+
+        return values;
+    }
+
     /**
      * Detect GPUs via rocminfo
      */
@@ -551,7 +737,8 @@ class ROCmDetector {
             for (let index = 0; index < agents.length; index += 1) {
                 const name = agents[index].name;
                 let vram = this.estimateVRAMFromGfxName(name);
-                vram = this.applyIntegratedVramHeuristic(name, vram);
+                const memoryProfile = this.resolveGpuMemoryProfile(name, vram);
+                vram = memoryProfile.total;
 
                 if (!Number.isFinite(vram) || vram <= 0) {
                     vram = 8;
@@ -560,11 +747,22 @@ class ROCmDetector {
                 result.gpus.push({
                     index,
                     name,
-                    memory: { total: vram, free: vram, used: 0 },
+                    type: memoryProfile.type,
+                    memory: {
+                        total: vram,
+                        free: vram,
+                        used: 0,
+                        dedicated: memoryProfile.dedicated,
+                        shared: memoryProfile.shared
+                    },
+                    dedicatedMemory: memoryProfile.dedicated,
+                    sharedMemory: memoryProfile.shared,
+                    unifiedMemory: memoryProfile.type === 'integrated' ? memoryProfile.shared : 0,
                     capabilities: this.getGPUCapabilities(name),
                     speedCoefficient: this.calculateSpeedCoefficient(name, vram)
                 });
-                result.totalVRAM += vram;
+                result.totalVRAM += memoryProfile.type === 'integrated' ? memoryProfile.dedicated : vram;
+                result.totalSharedMemory += memoryProfile.type === 'integrated' ? memoryProfile.shared : 0;
             }
 
             return result.gpus.length > 0;
@@ -776,6 +974,7 @@ class ROCmDetector {
 
         // RDNA 4 / Radeon AI PRO
         if (nameLower.includes('r9700') || nameLower.includes('ai pro') ||
+            nameLower.includes('rx 9070') || nameLower.includes('rx 9060') ||
             nameLower.includes('gfx1200') || nameLower.includes('gfx1201')) {
             capabilities.bf16 = true;
             capabilities.matrixCores = true;
@@ -837,11 +1036,17 @@ class ROCmDetector {
 
         // Known integrated/APU labels where ROCm can report small dedicated aperture
         if (nameLower.includes('gfx1151') || nameLower.includes('gfx1150') || nameLower.includes('gfx1152')) return 16;
+        if (nameLower.includes('radeon 8060s')) return 16;
         if (nameLower.includes('radeon 890m')) return 16;
         if (nameLower.includes('radeon 880m')) return 12;
         if (nameLower.includes('radeon 780m')) return 8;
+        if (nameLower.includes('radeon 680m')) return 8;
 
         // RDNA 4 / Radeon AI PRO
+        if (nameLower.includes('rx 9070 xt')) return 16;
+        if (nameLower.includes('rx 9070')) return 16;
+        if (nameLower.includes('rx 9060 xt')) return 16;
+        if (nameLower.includes('rx 9060')) return 8;
         if (nameLower.includes('r9700') || nameLower.includes('ai pro r9700')) return 32;
 
         // RX 7000 series
@@ -880,7 +1085,7 @@ class ROCmDetector {
     estimateVRAMFromGfxName(name) {
         const nameLower = (name || '').toLowerCase();
 
-        if (nameLower.includes('gfx1200') || nameLower.includes('gfx1201')) return 32; // Radeon AI PRO R9700
+        if (nameLower.includes('gfx1200') || nameLower.includes('gfx1201')) return 16; // RDNA 4 desktop default
         if (nameLower.includes('gfx1150') || nameLower.includes('gfx1151') || nameLower.includes('gfx1152')) return 16; // Strix Halo / Radeon 890M class
         if (nameLower.includes('gfx1100')) return 24;  // RX 7900 XTX
         if (nameLower.includes('gfx1101')) return 16;  // RX 7800
@@ -902,40 +1107,48 @@ class ROCmDetector {
         const nameLower = (name || '').toLowerCase();
 
         // Speed coefficients (tokens/sec per B params at Q4)
-        const speedMap = {
+        const speedMap = new Map([
             // RDNA 4 / Radeon AI PRO
-            'r9700': 230,
-            'ai pro r9700': 230,
+            ['ai pro r9700', 230],
+            ['r9700', 230],
+            ['rx 9070 xt', 190],
+            ['rx 9070', 175],
+            ['rx 9060 xt', 170],
+            ['rx 9060', 150],
+            ['radeon 8060s', 160],
+            ['gfx1151', 160],
+            ['gfx1150', 150],
+            ['gfx1152', 150],
 
             // RX 7000 series (RDNA 3)
-            '7900 xtx': 200,
-            '7900 xt': 180,
-            '7900 gre': 160,
-            '7800 xt': 150,
-            '7700 xt': 120,
-            '7600': 90,
+            ['7900 xtx', 200],
+            ['7900 xt', 180],
+            ['7900 gre', 160],
+            ['7800 xt', 150],
+            ['7700 xt', 120],
+            ['7600', 90],
 
             // RX 6000 series (RDNA 2)
-            '6950 xt': 150,
-            '6900 xt': 140,
-            '6800 xt': 130,
-            '6800': 120,
-            '6750 xt': 100,
-            '6700 xt': 90,
-            '6700': 80,
-            '6600 xt': 70,
-            '6600': 60,
+            ['6950 xt', 150],
+            ['6900 xt', 140],
+            ['6800 xt', 130],
+            ['6800', 120],
+            ['6750 xt', 100],
+            ['6700 xt', 90],
+            ['6700', 80],
+            ['6600 xt', 70],
+            ['6600', 60],
 
             // Instinct series
-            'mi300x': 400,
-            'mi300': 350,
-            'mi250x': 280,
-            'mi250': 250,
-            'mi210': 200,
-            'mi100': 150
-        };
+            ['mi300x', 400],
+            ['mi300', 350],
+            ['mi250x', 280],
+            ['mi250', 250],
+            ['mi210', 200],
+            ['mi100', 150]
+        ]);
 
-        for (const [model, speed] of Object.entries(speedMap)) {
+        for (const [model, speed] of speedMap) {
             if (nameLower.includes(model)) {
                 return speed;
             }

--- a/src/hardware/unified-detector.js
+++ b/src/hardware/unified-detector.js
@@ -307,7 +307,10 @@ class UnifiedDetector {
         summary.dedicatedGpuCount = topology.dedicatedCount;
         summary.integratedGpuModels = topology.integratedModels;
         summary.dedicatedGpuModels = topology.dedicatedModels;
-        summary.integratedSharedMemory = topology.integratedSharedMemory;
+        summary.integratedSharedMemory = Math.max(
+            topology.integratedSharedMemory,
+            this.getPrimaryIntegratedSharedMemory(primary)
+        );
         if (!summary.gpuModel) {
             summary.gpuModel = topology.primaryModel || null;
         }
@@ -324,9 +327,17 @@ class UnifiedDetector {
         summary.runtimeBackendName = runtimeSelection.name;
         summary.hasRuntimeAssist = runtimeSelection.assisted;
 
-        // Effective memory for LLM loading
-        // For GPU: use VRAM; for CPU/Metal: use system RAM
-        if (summary.totalVRAM > 0 && ['cuda', 'rocm', 'intel'].includes(primary?.type)) {
+        // Effective memory for LLM loading. Integrated ROCm/iGPU devices expose
+        // a small aperture as VRAM and a much larger shared pool for model-fit
+        // decisions, so avoid treating the aperture as dedicated VRAM.
+        if (
+            ['rocm', 'intel'].includes(primary?.type) &&
+            summary.hasIntegratedGPU &&
+            !summary.hasDedicatedGPU &&
+            summary.integratedSharedMemory > 0
+        ) {
+            summary.effectiveMemory = summary.integratedSharedMemory;
+        } else if (summary.totalVRAM > 0 && ['cuda', 'rocm', 'intel'].includes(primary?.type)) {
             summary.effectiveMemory = summary.totalVRAM;
         } else {
             // Use 70% of system RAM for models (leave room for OS)
@@ -337,6 +348,21 @@ class UnifiedDetector {
         summary.bestBackendLabel = this.getBestBackendLabel(summary);
 
         return summary;
+    }
+
+    getPrimaryIntegratedSharedMemory(primary) {
+        const gpus = Array.isArray(primary?.info?.gpus) ? primary.info.gpus : [];
+        return gpus
+            .filter((gpu) => gpu?.type === 'integrated')
+            .reduce((max, gpu) => {
+                const candidates = [
+                    gpu?.sharedMemory,
+                    gpu?.unifiedMemory,
+                    gpu?.memory?.shared,
+                    gpu?.memory?.total
+                ].map(Number).filter((value) => Number.isFinite(value) && value > 0);
+                return Math.max(max, ...candidates, 0);
+            }, 0);
     }
 
     classifyHardwareTierFromSummary(summary = {}) {
@@ -848,7 +874,11 @@ class UnifiedDetector {
         const summary = result.summary;
 
         // Leave headroom (2GB for GPU, 20% for RAM)
-        if (summary.bestBackend === 'cpu' || summary.bestBackend === 'metal') {
+        if (
+            summary.bestBackend === 'cpu' ||
+            summary.bestBackend === 'metal' ||
+            (summary.hasIntegratedGPU && !summary.hasDedicatedGPU && summary.integratedSharedMemory > 0)
+        ) {
             return sizeGB <= (summary.effectiveMemory - 2);
         } else {
             const availableVRAM = useMultiGPU ? summary.totalVRAM : (summary.totalVRAM / summary.gpuCount);
@@ -939,6 +969,10 @@ class UnifiedDetector {
             const gpuDesc = summary.gpuInventory || (
                 summary.isMultiGPU ? `${summary.gpuCount}x ${summary.gpuModel}` : summary.gpuModel
             );
+            if (summary.hasIntegratedGPU && !summary.hasDedicatedGPU && summary.integratedSharedMemory > 0) {
+                const dedicatedLabel = summary.totalVRAM > 0 ? `, ${summary.totalVRAM}GB aperture` : '';
+                return `${gpuDesc} (${summary.integratedSharedMemory}GB shared memory${dedicatedLabel}) + ${summary.cpuModel}`;
+            }
             return `${gpuDesc} (${summary.totalVRAM}GB VRAM) + ${summary.cpuModel}`;
         }
         else if (summary.bestBackend === 'metal') {

--- a/tests/multi-objective-selector-regression.test.js
+++ b/tests/multi-objective-selector-regression.test.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+const MultiObjectiveSelector = require('../src/ai/multi-objective-selector');
+const ExpandedModelsDatabase = require('../src/models/expanded_database');
+
+async function testRtx5060AvoidsTinyLlamaTopPick() {
+    const selector = new MultiObjectiveSelector();
+    const database = new ExpandedModelsDatabase();
+    const hardware = {
+        cpu: {
+            brand: 'Intel Core Ultra 7 255HX',
+            cores: 20,
+            physicalCores: 20,
+            speed: 3.0,
+            architecture: 'x64'
+        },
+        memory: { total: 15 },
+        gpu: {
+            model: 'NVIDIA GeForce RTX 5060 Laptop GPU',
+            vendor: 'NVIDIA',
+            vram: 8,
+            dedicated: true
+        },
+        summary: {
+            hasDedicatedGPU: true,
+            hasIntegratedGPU: false,
+            totalVRAM: 8
+        },
+        os: { platform: 'linux' }
+    };
+
+    assert.strictEqual(selector.getHardwareTier(hardware), 'medium');
+
+    const result = await selector.selectBestModels(hardware, database.getAllModels(), 'general', 10);
+    const top = result.compatible[0] || result.marginal[0];
+
+    assert.ok(top, 'Expected at least one recommendation');
+    assert.notStrictEqual(top.name, 'TinyLlama 1.1B', 'RTX 5060 should not recommend TinyLlama as top pick');
+    assert.ok(
+        selector.estimateModelParams(top) >= 6 && selector.estimateModelParams(top) <= 9,
+        `Expected a 6B-9B top recommendation for RTX 5060, got ${top.name}`
+    );
+}
+
+async function run() {
+    await testRtx5060AvoidsTinyLlamaTopPick();
+    console.log('multi-objective-selector-regression.test.js: OK');
+}
+
+if (require.main === module) {
+    run().catch((error) => {
+        console.error('multi-objective-selector-regression.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = { run };

--- a/tests/rocm-vram-parsing.test.js
+++ b/tests/rocm-vram-parsing.test.js
@@ -56,10 +56,86 @@ function testIntegratedApertureHeuristic() {
     assert.ok(corrected >= 8, 'Integrated tiny aperture values should be corrected to a practical floor');
 }
 
+function testRocmSmiProductNameAnchorsCardSeries() {
+    const detector = new ROCmDetector();
+    const sample = [
+        'GPU[0]\t\t: Card Series: \t\tAMD Radeon RX 9060 XT',
+        'GPU[0]\t\t: Card Model: \t\t0x7590',
+        'GPU[0]\t\t: GFX Version: \t\tgfx1200'
+    ].join('\n');
+
+    const parsed = detector.parseRocmSmiProductNames(sample);
+
+    assert.strictEqual(
+        parsed[0],
+        'AMD Radeon RX 9060 XT',
+        'Card Series should not be overwritten by later GFX Version lines'
+    );
+}
+
+function testRocmSmiVramParserSkipsUsedMemory() {
+    const detector = new ROCmDetector();
+    const sample = [
+        'GPU[0]\t\t: VRAM Total Memory (B): 17095983104',
+        'GPU[0]\t\t: VRAM Total Used Memory (B): 1729613824'
+    ].join('\n');
+
+    const parsed = detector.parseRocmSmiMemoryInfo(sample);
+
+    assert.strictEqual(parsed[0], 16, 'VRAM total should remain 16GB and not be overwritten by used memory');
+}
+
+function testRdna4Rx9060Capabilities() {
+    const detector = new ROCmDetector();
+    const capabilities = detector.getGPUCapabilities('AMD Radeon RX 9060 XT');
+
+    assert.strictEqual(detector.estimateVRAMFromModel('AMD Radeon RX 9060 XT'), 16);
+    assert.strictEqual(detector.calculateSpeedCoefficient('AMD Radeon RX 9060 XT', 16), 170);
+    assert.strictEqual(capabilities.architecture, 'RDNA 4');
+    assert.strictEqual(capabilities.gfxVersion, 'gfx1200');
+}
+
+function testRocmInfoDedupeByGfxAlias() {
+    const detector = new ROCmDetector();
+    const sample = [
+        'Agent 1:',
+        '  Name: gfx1035',
+        '  Marketing Name: AMD Radeon Graphics',
+        '  Device Type: GPU',
+        '',
+        'Agent 2:',
+        '  Name: amdgcn-amd-amdhsa--gfx1035',
+        '  Marketing Name: AMD',
+        '  Device Type: GPU'
+    ].join('\n');
+
+    const parsed = detector.parseRocmInfoGpuAgents(sample);
+
+    assert.strictEqual(parsed.length, 1, 'Aliases for the same gfx target should not be counted as separate GPUs');
+    assert.strictEqual(parsed[0].name, 'AMD Radeon Graphics');
+}
+
+function testIntegratedSharedMemoryProfile() {
+    const detector = new ROCmDetector();
+    detector.getIntegratedMemoryProfile = () => ({ dedicated: 1, shared: 112 });
+
+    const profile = detector.resolveGpuMemoryProfile('AMD Radeon 8060S (gfx1151)', 1);
+
+    assert.strictEqual(profile.type, 'integrated');
+    assert.strictEqual(profile.dedicated, 1);
+    assert.strictEqual(profile.shared, 112);
+    assert.strictEqual(profile.total, 112);
+}
+
 function run() {
     testRocmMemoryNormalization();
     testRocmInfoParsingDedupesGpuAgents();
     testIntegratedApertureHeuristic();
+    testRocmSmiProductNameAnchorsCardSeries();
+    testRocmSmiVramParserSkipsUsedMemory();
+    testRdna4Rx9060Capabilities();
+    testRocmInfoDedupeByGfxAlias();
+    testIntegratedSharedMemoryProfile();
     console.log('✅ rocm-vram-parsing.test.js passed');
 }
 

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -17,6 +17,7 @@ const TESTS = [
     { name: 'Termux platform support', file: 'termux-platform-support.test.js', category: 'Hardware' },
     { name: 'Token speed estimation', file: 'token-speed-estimation.test.js', category: 'Performance' },
     { name: 'Deterministic model pool', file: 'deterministic-model-pool-check.js', category: 'Recommendations' },
+    { name: 'Multi-objective selector regression', file: 'multi-objective-selector-regression.test.js', category: 'Recommendations' },
     { name: 'Fine-tuning support helper', file: 'fine-tuning-support.test.js', category: 'Recommendations' },
     { name: 'Ollama capacity planner', file: 'ollama-capacity-planner.test.js', category: 'Ollama' },
     { name: 'Ollama localhost fallback', file: 'ollama-client-localhost-fallback.test.js', category: 'Ollama' },


### PR DESCRIPTION
## Summary
- fix ROCm product-name and VRAM parsing so Card Series and VRAM Total Memory are not overwritten by later rocm-smi fields
- add RX 9060/9070 RDNA4 mappings and speed/capability handling
- handle integrated ROCm shared memory/GTT pools without counting aliases as multiple GPUs
- correct RTX 5060-class model sizing/tiering so 7B/8B models outrank TinyLlama

Fixes #75
Fixes #76
Fixes #79
Fixes #80

## Verification
- node tests/rocm-vram-parsing.test.js
- node tests/multi-objective-selector-regression.test.js
- node tests/ui-cli-smoke.test.js
- node tests/token-speed-estimation.test.js (outside sandbox)
- node tests/ollama-client-native-fetch-fallback.test.js (outside sandbox)
- node tests/local-features-e2e.test.js (outside sandbox)
- node tests/run-all-tests.js (30/34 in sandbox; remaining failures were sandbox permissions for sysctl/listen and unavailable local Ollama daemon)