### PR TITLE
fix(ui): resolve Windows panel redraw flicker and lock canonical banner

### DIFF
--- a/src/ui/cli-theme.js
+++ b/src/ui/cli-theme.js
@@ -4,6 +4,7 @@ const chalk = require('chalk');
 const { execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
+const readline = require('readline');
 
 // Adapted from /Users/pchmirenko/Downloads/ascii-motion-cli.tsx frame model.
 const THEME_DARK = {
@@ -41,6 +42,8 @@ const FRAMES_PER_SECOND = 14;
 // Security: do not auto-load executable-style banner sources from user-writable folders.
 // External banner loading is opt-in via LLM_CHECKER_BANNER_SOURCE and supports JSON only.
 const DEFAULT_BANNER_SOURCE = null;
+// Canonical startup banner asset. Do not edit casually: treat as product identity.
+// Any intentional change should update tests/banner-canonical.test.js in the same commit.
 const BUNDLED_TEXT_BANNER_SOURCE = path.join(__dirname, 'banner-profesional-v2.txt');
 const DEFAULT_TEXT_BANNER_SOURCES = [
     BUNDLED_TEXT_BANNER_SOURCE
@@ -79,7 +82,14 @@ function sleep(ms) {
 }
 
 function clearTerminal() {
-    process.stdout.write('\x1b[2J\x1b[0f');
+    if (!process.stdout.isTTY) return;
+
+    try {
+        readline.cursorTo(process.stdout, 0, 0);
+        readline.clearScreenDown(process.stdout);
+    } catch {
+        process.stdout.write('\x1b[2J\x1b[H');
+    }
 }
 
 function parseDarkBackgroundValue(value) {

--- a/src/ui/interactive-panel.js
+++ b/src/ui/interactive-panel.js
@@ -32,7 +32,14 @@ const REQUIRED_ARG_PROMPTS = {
 };
 
 function clearTerminal() {
-    process.stdout.write('\x1b[2J\x1b[0f');
+    if (!process.stdout.isTTY) return;
+
+    try {
+        readline.cursorTo(process.stdout, 0, 0);
+        readline.clearScreenDown(process.stdout);
+    } catch {
+        process.stdout.write('\x1b[2J\x1b[H');
+    }
 }
 
 function truncateText(text, maxLength) {
@@ -311,6 +318,18 @@ function renderPanel(state, catalog, primaryCommands, options = {}) {
     );
 }
 
+function shouldEnableBannerPulse({
+    isTTY = process.stdout.isTTY,
+    disableAnimation = process.env.LLM_CHECKER_DISABLE_ANIMATION,
+    forcePulse = process.env.LLM_CHECKER_FORCE_PANEL_PULSE,
+    platform = process.platform
+} = {}) {
+    if (!isTTY) return false;
+    if (disableAnimation === '1') return false;
+    if (forcePulse === '1') return true;
+    return platform !== 'win32';
+}
+
 async function collectCommandArgs(commandMeta) {
     const prompts = [];
     const requiredPrompts = REQUIRED_ARG_PROMPTS[commandMeta.name] || [];
@@ -421,9 +440,7 @@ async function launchInteractivePanel(options) {
     readline.emitKeypressEvents(process.stdin);
 
     return new Promise((resolve) => {
-        const shouldPulseBanner =
-            process.stdout.isTTY &&
-            process.env.LLM_CHECKER_DISABLE_ANIMATION !== '1';
+        const shouldPulseBanner = shouldEnableBannerPulse();
         let pulseTimer = null;
 
         const stopBannerPulse = () => {
@@ -578,6 +595,7 @@ module.exports = {
         buildCommandCatalog,
         buildPrimaryCommands,
         getVisibleCommands,
-        truncateText
+        truncateText,
+        shouldEnableBannerPulse
     }
 };

--- a/tests/banner-canonical.test.js
+++ b/tests/banner-canonical.test.js
@@ -1,0 +1,41 @@
+const assert = require('assert');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+
+const BANNER_PATH = path.resolve(__dirname, '..', 'src', 'ui', 'banner-profesional-v2.txt');
+const CANONICAL_BANNER_SHA256 = 'ddbc9788510a1577b6b584b46e4eb60409e46f8708305e6cbd6ec61e847f87f3';
+
+function run() {
+    const raw = fs.readFileSync(BANNER_PATH, 'utf8');
+    const normalized = raw.replace(/\r\n/g, '\n');
+    const digest = crypto.createHash('sha256').update(normalized, 'utf8').digest('hex');
+
+    assert.ok(
+        normalized.includes('[ INTELLIGENT OLLAMA MODEL SELECTOR ]'),
+        'canonical banner header marker is missing'
+    );
+    assert.ok(
+        normalized.includes('[200+ DYNAMIC MODELS]'),
+        'canonical banner features marker is missing'
+    );
+    assert.strictEqual(
+        digest,
+        CANONICAL_BANNER_SHA256,
+        'startup banner changed: this file is treated as canonical product identity and must not be modified without explicit approval'
+    );
+
+    console.log('banner-canonical.test.js: OK');
+}
+
+if (require.main === module) {
+    try {
+        run();
+    } catch (error) {
+        console.error('banner-canonical.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+module.exports = { run };

--- a/tests/cli-interactive-panel.test.js
+++ b/tests/cli-interactive-panel.test.js
@@ -9,7 +9,8 @@ const {
         buildCommandCatalog,
         buildPrimaryCommands,
         getVisibleCommands,
-        truncateText
+        truncateText,
+        shouldEnableBannerPulse
     }
 } = require('../src/ui/interactive-panel');
 
@@ -104,6 +105,37 @@ function run() {
         visibleOpen.map((item) => item.name),
         ['search'],
         'open palette should filter commands by query'
+    );
+
+    assert.strictEqual(
+        shouldEnableBannerPulse({ isTTY: true, platform: 'linux', disableAnimation: '0' }),
+        true,
+        'pulse should run on non-Windows TTY terminals'
+    );
+    assert.strictEqual(
+        shouldEnableBannerPulse({ isTTY: true, platform: 'win32', disableAnimation: '0' }),
+        false,
+        'pulse should be disabled on Windows by default to avoid redraw flicker'
+    );
+    assert.strictEqual(
+        shouldEnableBannerPulse({
+            isTTY: true,
+            platform: 'win32',
+            disableAnimation: '0',
+            forcePulse: '1'
+        }),
+        true,
+        'pulse can be explicitly re-enabled on Windows when requested'
+    );
+    assert.strictEqual(
+        shouldEnableBannerPulse({ isTTY: false, platform: 'linux', disableAnimation: '0' }),
+        false,
+        'pulse should stay off for non-TTY outputs'
+    );
+    assert.strictEqual(
+        shouldEnableBannerPulse({ isTTY: true, platform: 'linux', disableAnimation: '1' }),
+        false,
+        'pulse should respect disable animation env'
     );
 
     console.log('cli-interactive-panel.test.js: OK');

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -28,6 +28,7 @@ const TESTS = [
     { name: 'Ollama selector IPv6 fallback', file: 'ollama-selector-ipv6-fallback.test.js', category: 'Ollama' },
     { name: 'Ollama speed metrics', file: 'ollama-client-speed-metrics.test.js', category: 'Ollama' },
     { name: 'Runtime + speculative decoding', file: 'runtime-specdec-tests.js', category: 'Runtime' },
+    { name: 'Startup banner canonical integrity', file: 'banner-canonical.test.js', category: 'UI' },
     { name: 'CLI interface smoke', file: 'ui-cli-smoke.test.js', category: 'UI' },
     { name: 'CLI interactive panel helpers', file: 'cli-interactive-panel.test.js', category: 'UI' },
     { name: 'Local features end-to-end', file: 'local-features-e2e.test.js', category: 'E2E' },


### PR DESCRIPTION
## Summary
- fixes interactive panel redraw behavior that caused repeated scroll/flicker reports on Windows terminals
- replaces raw full-screen ANSI clear with `readline.cursorTo(..., 0, 0)` + `readline.clearScreenDown(...)` and safe fallback escape sequence
- disables the 120ms banner pulse loop on Windows by default (`LLM_CHECKER_FORCE_PANEL_PULSE=1` can explicitly opt in)
- adds a canonical banner integrity test so startup banner changes are intentional and review-gated
- documents banner asset in code as product identity with explicit no-touch guidance

## Why this addresses #83
Issue #83 reports that panel redraw keeps printing instead of replacing content in PowerShell/Windows Terminal. The pulse loop was forcing full rerender continuously; if clear handling is not interpreted consistently, each frame appends. This change removes the aggressive default pulse on Windows and uses cursor-based redraw primitives that are more compatible.

## Validation
- `node tests/banner-canonical.test.js`
- `node tests/cli-interactive-panel.test.js`
- `node tests/ui-cli-smoke.test.js`
- `npm test` (35/35 passing)

Closes #83
