### PR TITLE
chore(release): prepare 3.5.15

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.5.14",
+  "version": "3.5.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.5.14",
+      "version": "3.5.15",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.5.14",
+  "version": "3.5.15",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",


### PR DESCRIPTION
## Summary
- align repository package metadata with published npm version 3.5.15
- keeps GitHub main and npm latest in sync after publishing the Windows redraw follow-up

## Validation
- npm test (35/35 passing before this metadata-only commit)
- npm view llm-checker version => 3.5.15
