### PR TITLE
Fix Windows panel redraw and high-capacity recommendations

### DIFF
--- a/src/models/deterministic-selector.js
+++ b/src/models/deterministic-selector.js
@@ -1556,10 +1556,21 @@ class DeterministicModelSelector {
         const S = speedEstimate.score;
         const F = this.calculateFitScore(requiredGB, budget);
         const C = this.calculateContextScore(model, targetCtx);
+        const capacityAdjustment = this.calculateHighCapacitySizeAdjustment(
+            hardware,
+            model,
+            budget,
+            category,
+            optimizeFor
+        );
 
         // 4. Calculate final weighted score
         const weights = this.getScoringWeights(category, optimizeFor);
-        const score = Math.round((Q * weights[0] + S * weights[1] + F * weights[2] + C * weights[3]) * 10) / 10;
+        const weightedScore = Q * weights[0] + S * weights[1] + F * weights[2] + C * weights[3];
+        const score = Math.max(
+            0,
+            Math.min(100, Math.round((weightedScore + capacityAdjustment.score) * 10) / 10)
+        );
 
         // 5. Build rationale
         const rationale = this.buildRationale(
@@ -1572,7 +1583,8 @@ class DeterministicModelSelector {
             Q,
             S,
             memoryEstimate,
-            speedEstimate
+            speedEstimate,
+            capacityAdjustment
         );
 
         return {
@@ -1599,7 +1611,7 @@ class DeterministicModelSelector {
                 runtime: speedEstimate.runtime,
                 moe: speedEstimate.moe
             },
-            components: { Q, S, F, C }
+            components: { Q, S, F, C, H: capacityAdjustment.score }
         };
     }
 
@@ -1858,6 +1870,9 @@ class DeterministicModelSelector {
         if (hardware.cpu.cores >= 8) base *= 1.1;
         if (hardware.acceleration.supports_metal || hardware.acceleration.supports_cuda) base *= 1.2;
 
+        const acceleratorScale = this.calculateAcceleratorSpeedScale(hardware, backend);
+        base *= acceleratorScale.multiplier;
+
         const normalizedRuntime = normalizeMoERuntime(runtime);
         const moe = estimateMoESpeedMultiplier({
             model,
@@ -1880,7 +1895,46 @@ class DeterministicModelSelector {
             estimatedTPS,
             score,
             runtime: normalizedRuntime,
-            moe
+            moe,
+            acceleratorScale
+        };
+    }
+
+    calculateAcceleratorSpeedScale(hardware = {}, backend = 'cpu_x86') {
+        if (backend !== 'cuda' && backend !== 'metal') {
+            return { multiplier: 1, reason: null };
+        }
+
+        const gpu = hardware.gpu || {};
+        const memory = hardware.memory || {};
+        const toFiniteNumber = (value, fallback = 0) => {
+            const parsed = Number(value);
+            return Number.isFinite(parsed) ? parsed : fallback;
+        };
+        const vramGB = toFiniteNumber(gpu.vramGB ?? gpu.vram ?? gpu.totalVRAM, 0);
+        const ramGB = toFiniteNumber(memory.totalGB ?? memory.total, 0);
+        const acceleratorMemoryGB = backend === 'metal' && Boolean(gpu.unified)
+            ? Math.max(vramGB, ramGB)
+            : vramGB;
+        const gpuCount = Math.max(1, toFiniteNumber(gpu.gpuCount ?? gpu.count, 1));
+
+        let multiplier = 1;
+        if (acceleratorMemoryGB >= 160) multiplier *= 3.2;
+        else if (acceleratorMemoryGB >= 96) multiplier *= 2.6;
+        else if (acceleratorMemoryGB >= 80) multiplier *= 2.2;
+        else if (acceleratorMemoryGB >= 48) multiplier *= 1.7;
+        else if (acceleratorMemoryGB >= 24) multiplier *= 1.15;
+
+        if (backend === 'cuda' && gpuCount > 1) {
+            multiplier *= Math.min(1.8, 1 + ((gpuCount - 1) * 0.25));
+        }
+
+        const rounded = Math.round(multiplier * 100) / 100;
+        return {
+            multiplier: rounded,
+            reason: rounded > 1
+                ? `${backend.toUpperCase()} capacity x${rounded}`
+                : null
         };
     }
 
@@ -1895,6 +1949,68 @@ class DeterministicModelSelector {
         if (model.ctxMax >= targetCtx) return 100;
         if (model.ctxMax >= targetCtx * 0.5) return 70;
         return 0; // Should be filtered out earlier
+    }
+
+    getHighCapacitySizeTarget(budgetGB, hardware = {}) {
+        if (!Number.isFinite(budgetGB) || budgetGB < 32) return null;
+
+        const isMultiGPU = Boolean(hardware?.gpu?.isMultiGPU);
+        if (budgetGB >= 128) return { minParamsB: 30, sweetSpotParamsB: 70 };
+        if (budgetGB >= 80) return { minParamsB: 30, sweetSpotParamsB: 70 };
+        if (budgetGB >= 48) return { minParamsB: 20, sweetSpotParamsB: 34 };
+        if (budgetGB >= 32 && isMultiGPU) return { minParamsB: 30, sweetSpotParamsB: 30 };
+        if (budgetGB >= 32) return { minParamsB: 13, sweetSpotParamsB: 30 };
+        return null;
+    }
+
+    calculateHighCapacitySizeAdjustment(hardware, model, budgetGB, category, optimizeFor = 'balanced') {
+        const objective = this.normalizeOptimizationObjective(optimizeFor);
+        if (objective === 'speed' || category === 'embeddings') {
+            return { score: 0, reason: null };
+        }
+
+        const normalizedHardware = this.normalizeHardwareProfile(hardware || {});
+        const tier = this.mapHardwareTier(normalizedHardware);
+        const highCapacityTiers = new Set(['very_high', 'ultra_high', 'extreme', 'flagship']);
+        const target = this.getHighCapacitySizeTarget(budgetGB, normalizedHardware);
+        const hasHighCapacitySignal =
+            Boolean(target) ||
+            highCapacityTiers.has(tier) ||
+            Number(normalizedHardware?.gpu?.vramGB || 0) >= 48;
+
+        if (!hasHighCapacitySignal || !target) {
+            return { score: 0, reason: null };
+        }
+
+        const params = this.parseBillionsValue(model?.paramsB);
+        if (!Number.isFinite(params) || params <= 0) {
+            return { score: 0, reason: null };
+        }
+
+        const categoryMultiplier = category === 'multimodal' ? 0.6 : 1;
+        if (params < target.minParamsB) {
+            const deficitRatio = (target.minParamsB - params) / target.minParamsB;
+            const penalty = -Math.min(24, deficitRatio * 24) * categoryMultiplier;
+            const roundedPenalty = Math.round(penalty * 10) / 10;
+            return {
+                score: roundedPenalty,
+                reason: `below ${target.minParamsB}B high-capacity floor`
+            };
+        }
+
+        const distanceRatio = Math.min(
+            1,
+            Math.abs(params - target.sweetSpotParamsB) / target.sweetSpotParamsB
+        );
+        const bonus = Math.max(0, 12 * (1 - distanceRatio)) * categoryMultiplier;
+        const roundedBonus = Math.round(bonus * 10) / 10;
+
+        return {
+            score: roundedBonus,
+            reason: roundedBonus > 0
+                ? `${target.sweetSpotParamsB}B high-capacity target`
+                : null
+        };
     }
 
     estimatePracticalMaxParamsForBudget(budgetGB) {
@@ -1994,7 +2110,19 @@ class DeterministicModelSelector {
         return highCapacityPromoted;
     }
 
-    buildRationale(hardware, model, quant, requiredGB, budget, category, Q, S, memoryEstimate = null, speedEstimate = null) {
+    buildRationale(
+        hardware,
+        model,
+        quant,
+        requiredGB,
+        budget,
+        category,
+        Q,
+        S,
+        memoryEstimate = null,
+        speedEstimate = null,
+        capacityAdjustment = null
+    ) {
         const parts = [];
         
         // Memory fit
@@ -2026,6 +2154,14 @@ class DeterministicModelSelector {
             const runtimeLabel = speedEstimate.runtime || 'ollama';
             const multiplier = Number(speedEstimate.moe.multiplier || 1).toFixed(2);
             parts.push(`MoE speed x${multiplier} (${runtimeLabel})`);
+        }
+
+        if (speedEstimate?.acceleratorScale?.multiplier > 1) {
+            parts.push(speedEstimate.acceleratorScale.reason);
+        }
+
+        if (capacityAdjustment?.reason) {
+            parts.push(capacityAdjustment.reason);
         }
         
         // Size sweet spot

--- a/src/ui/cli-theme.js
+++ b/src/ui/cli-theme.js
@@ -81,14 +81,42 @@ function sleep(ms) {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-function clearTerminal() {
+function getSafeTerminalWidth(columns = process.stdout.columns, platform = process.platform) {
+    const value = Number(columns);
+    if (!Number.isFinite(value) || value <= 0) return null;
+
+    const width = Math.floor(value);
+    // Windows terminals commonly wrap when output writes exactly `columns` cells.
+    // Keep the canonical banner intact while rendering one cell inside the edge.
+    if (platform === 'win32') {
+        return Math.max(20, width - 1);
+    }
+
+    return Math.max(20, width);
+}
+
+function getTerminalClearSequence(platform = process.platform) {
+    if (platform === 'win32') {
+        return '\x1b[1;1H\x1b[0J';
+    }
+
+    return '\x1b[2J\x1b[H';
+}
+
+function clearTerminal(options = {}) {
     if (!process.stdout.isTTY) return;
+
+    const platform = options.platform || process.platform;
+    if (platform === 'win32') {
+        process.stdout.write(getTerminalClearSequence(platform));
+        return;
+    }
 
     try {
         readline.cursorTo(process.stdout, 0, 0);
         readline.clearScreenDown(process.stdout);
     } catch {
-        process.stdout.write('\x1b[2J\x1b[H');
+        process.stdout.write(getTerminalClearSequence(platform));
     }
 }
 
@@ -338,9 +366,10 @@ function drawTextBanner(lines, options = {}) {
     const colorPhase = Number.isFinite(options.colorPhase)
         ? Math.max(0, Math.floor(options.colorPhase))
         : 0;
-    const terminalWidth = Number.isFinite(process.stdout.columns) && process.stdout.columns > 0
-        ? process.stdout.columns
-        : null;
+    const terminalWidth = getSafeTerminalWidth(
+        options.columns ?? process.stdout.columns,
+        options.platform || process.platform
+    );
 
     const centerToWidth = (text, width) => {
         const value = String(text || '').replace(/\s+$/g, '');
@@ -400,7 +429,7 @@ function drawTextBanner(lines, options = {}) {
 
         const frameMatch = line.match(/^(\s*\|)(.*)(\|\s*)$/);
         if (!frameMatch) {
-            console.log(line);
+            console.log(terminalWidth ? fitLine(line, terminalWidth) : line);
             continue;
         }
 
@@ -738,6 +767,11 @@ module.exports = {
     __private: {
         detectDarkBackgroundFromColorFgbg,
         detectDarkBackgroundFromMacOsAppearance,
+        fitLine,
+        drawTextBanner,
+        clearTerminal,
+        getSafeTerminalWidth,
+        getTerminalClearSequence,
         makeFrames,
         drawFrame,
         resolveHasDarkBackground

--- a/src/ui/interactive-panel.js
+++ b/src/ui/interactive-panel.js
@@ -4,7 +4,14 @@ const chalk = require('chalk');
 const inquirer = require('inquirer');
 const readline = require('readline');
 const { spawn } = require('child_process');
-const { animateBanner, renderPersistentBanner } = require('./cli-theme');
+const {
+    animateBanner,
+    renderPersistentBanner,
+    __private: {
+        clearTerminal,
+        getSafeTerminalWidth
+    }
+} = require('./cli-theme');
 
 const PRIMARY_COMMAND_PRIORITY = [
     'check',
@@ -31,22 +38,49 @@ const REQUIRED_ARG_PROMPTS = {
     ]
 };
 
-function clearTerminal() {
-    if (!process.stdout.isTTY) return;
-
-    try {
-        readline.cursorTo(process.stdout, 0, 0);
-        readline.clearScreenDown(process.stdout);
-    } catch {
-        process.stdout.write('\x1b[2J\x1b[H');
-    }
-}
-
 function truncateText(text, maxLength) {
     const value = String(text || '');
     if (value.length <= maxLength) return value;
     if (maxLength <= 3) return value.slice(0, maxLength);
     return `${value.slice(0, maxLength - 3)}...`;
+}
+
+function getPanelWidth({
+    columns = process.stdout.columns,
+    platform = process.platform
+} = {}) {
+    const safeWidth = getSafeTerminalWidth(columns, platform) || 100;
+    return Math.max(40, Math.min(safeWidth, 128));
+}
+
+function getTerminalRows(rows = process.stdout.rows) {
+    const value = Number(rows);
+    if (!Number.isFinite(value) || value <= 0) return null;
+    return Math.floor(value);
+}
+
+function shouldUseCompactPanelLayout({
+    rows = process.stdout.rows,
+    platform = process.platform,
+    forceFullBanner = process.env.LLM_CHECKER_FORCE_FULL_PANEL_BANNER
+} = {}) {
+    if (forceFullBanner === '1') return false;
+
+    const terminalRows = getTerminalRows(rows);
+    if (!terminalRows) return false;
+
+    if (platform === 'win32' && terminalRows < 64) return true;
+    return terminalRows < 46;
+}
+
+function getMaxCommandRows({
+    rows = process.stdout.rows,
+    compact = false
+} = {}) {
+    const terminalRows = getTerminalRows(rows) || 40;
+    const reservedRows = compact ? 9 : 47;
+    const minimumRows = compact ? 4 : 3;
+    return Math.max(minimumRows, Math.min(16, terminalRows - reservedRows));
 }
 
 function tokenizeArgString(rawInput = '') {
@@ -252,10 +286,16 @@ function getCommandWindow(commands, selectedIndex, maxRows) {
 
 function renderPanel(state, catalog, primaryCommands, options = {}) {
     const colorPhase = Number.isFinite(options.colorPhase) ? options.colorPhase : 0;
-    const width = Math.max(76, Math.min(process.stdout.columns || 100, 128));
+    const platform = options.platform || process.platform;
+    const rows = options.rows ?? process.stdout.rows;
+    const columns = options.columns ?? process.stdout.columns;
+    const compact = typeof options.compact === 'boolean'
+        ? options.compact
+        : shouldUseCompactPanelLayout({ rows, platform });
+    const width = getPanelWidth({ columns, platform });
     const separator = '-'.repeat(width - 2);
     const visibleCommands = getVisibleCommands(state, catalog, primaryCommands);
-    const maxCommandRows = Math.max(6, Math.min(16, (process.stdout.rows || 40) - 28));
+    const maxCommandRows = getMaxCommandRows({ rows, compact });
     const selectedIndex =
         visibleCommands.length > 0
             ? Math.max(0, Math.min(state.selected, visibleCommands.length - 1))
@@ -265,11 +305,17 @@ function renderPanel(state, catalog, primaryCommands, options = {}) {
     }
     const commandWindow = getCommandWindow(visibleCommands, selectedIndex, maxCommandRows);
 
-    clearTerminal();
-    renderPersistentBanner(undefined, { colorPhase });
-    console.log('');
+    clearTerminal({ platform });
+    if (compact) {
+        console.log(chalk.cyan.bold('llm-checker | Interactive command panel'));
+    } else {
+        renderPersistentBanner(undefined, { colorPhase, columns, platform });
+        console.log('');
+    }
     console.log(chalk.gray(separator));
-    const inputLabel = state.paletteOpen ? `/${state.query}` : '';
+    const inputLabel = state.paletteOpen
+        ? truncateText(`/${state.query}`, Math.max(1, width - 4))
+        : '';
     console.log(`${chalk.white.bold('>')} ${chalk.white(inputLabel)}${chalk.gray('|')}`);
     console.log(chalk.gray(separator));
 
@@ -282,8 +328,8 @@ function renderPanel(state, catalog, primaryCommands, options = {}) {
     if (visibleCommands.length === 0) {
         console.log(chalk.yellow('No commands match your query.'));
     } else {
-        const commandCol = 26;
-        const descCol = Math.max(18, width - commandCol - 8);
+        const commandCol = Math.min(26, Math.max(12, Math.floor(width * 0.36)));
+        const descCol = Math.max(8, width - commandCol - 2);
         const hiddenAbove = commandWindow.start;
         const hiddenBelow = visibleCommands.length - commandWindow.end;
 
@@ -314,7 +360,7 @@ function renderPanel(state, catalog, primaryCommands, options = {}) {
     console.log('');
     console.log(chalk.gray(separator));
     console.log(
-        chalk.gray('up/down navigate | Enter run | / open all | Esc close all | q exit')
+        chalk.gray(truncateText('up/down navigate | Enter run | / open all | Esc close all | q exit', width))
     );
 }
 
@@ -434,7 +480,9 @@ async function launchInteractivePanel(options) {
         renderPanel(state, catalog, primaryCommands, { colorPhase: state.colorPhase });
     };
 
-    await animateBanner({ text: appName });
+    if (!shouldUseCompactPanelLayout()) {
+        await animateBanner({ text: appName });
+    }
     renderNow();
 
     readline.emitKeypressEvents(process.stdin);
@@ -596,6 +644,9 @@ module.exports = {
         buildPrimaryCommands,
         getVisibleCommands,
         truncateText,
-        shouldEnableBannerPulse
+        shouldEnableBannerPulse,
+        getPanelWidth,
+        getMaxCommandRows,
+        shouldUseCompactPanelLayout
     }
 };

--- a/tests/cli-interactive-panel.test.js
+++ b/tests/cli-interactive-panel.test.js
@@ -10,9 +10,39 @@ const {
         buildPrimaryCommands,
         getVisibleCommands,
         truncateText,
-        shouldEnableBannerPulse
+        shouldEnableBannerPulse,
+        getPanelWidth,
+        getMaxCommandRows,
+        shouldUseCompactPanelLayout
     }
 } = require('../src/ui/interactive-panel');
+const {
+    __private: {
+        drawTextBanner,
+        getSafeTerminalWidth,
+        getTerminalClearSequence
+    }
+} = require('../src/ui/cli-theme');
+
+function stripAnsi(value) {
+    return String(value).replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, '');
+}
+
+function captureConsoleLogs(callback) {
+    const originalLog = console.log;
+    const logs = [];
+    console.log = (...args) => {
+        logs.push(args.join(' '));
+    };
+
+    try {
+        callback();
+    } finally {
+        console.log = originalLog;
+    }
+
+    return logs;
+}
 
 function createMockCommand(name, description) {
     return {
@@ -136,6 +166,80 @@ function run() {
         shouldEnableBannerPulse({ isTTY: true, platform: 'linux', disableAnimation: '1' }),
         false,
         'pulse should respect disable animation env'
+    );
+
+    assert.strictEqual(
+        getSafeTerminalWidth(207, 'win32'),
+        206,
+        'Windows rendering should stay one cell inside the reported terminal width'
+    );
+    assert.strictEqual(
+        getSafeTerminalWidth(207, 'linux'),
+        207,
+        'Non-Windows rendering can use the reported terminal width'
+    );
+    assert.strictEqual(
+        getTerminalClearSequence('win32'),
+        '\x1b[1;1H\x1b[0J',
+        'Windows clear sequence should move home before clearing below'
+    );
+    assert.strictEqual(
+        getPanelWidth({ columns: 207, platform: 'win32' }),
+        128,
+        'wide Windows panel should still respect the 128-column design cap'
+    );
+    assert.strictEqual(
+        getPanelWidth({ columns: 60, platform: 'win32' }),
+        59,
+        'narrow Windows panel should not force the old 76-column minimum'
+    );
+    assert.strictEqual(
+        shouldUseCompactPanelLayout({ rows: 50, platform: 'win32' }),
+        true,
+        'Windows terminals under 64 rows should use the compact panel header'
+    );
+    assert.strictEqual(
+        shouldUseCompactPanelLayout({ rows: 50, platform: 'linux' }),
+        false,
+        'non-Windows terminals at 50 rows can keep the full banner'
+    );
+    assert.strictEqual(
+        getMaxCommandRows({ rows: 50, compact: true }),
+        16,
+        'compact panel should leave enough room for the command list at 50 rows'
+    );
+    assert.strictEqual(
+        getMaxCommandRows({ rows: 50, compact: false }),
+        3,
+        'full banner layout should not overflow a 50-row terminal'
+    );
+
+    const bannerLogs = captureConsoleLogs(() => {
+        drawTextBanner(
+            [
+                ' +------+ ',
+                ' | █████████████████████████████████████████████████████████████████████████████ | ',
+                ' | INTELLIGENT OLLAMA MODEL SELECTOR | ',
+                ' +------+ '
+            ],
+            { columns: 207, platform: 'win32', hasDarkBackground: true }
+        );
+    }).map(stripAnsi);
+
+    assert.ok(bannerLogs.length > 0, 'banner layout test should capture rendered lines');
+    assert.ok(
+        bannerLogs.every((line) => line.length <= 206),
+        `Windows banner lines should not exceed safe width: ${bannerLogs.map((line) => line.length).join(', ')}`
+    );
+    assert.strictEqual(
+        bannerLogs[0].length,
+        206,
+        'top border should match safe Windows width'
+    );
+    assert.strictEqual(
+        bannerLogs[bannerLogs.length - 1].length,
+        206,
+        'bottom border should match safe Windows width'
     );
 
     console.log('cli-interactive-panel.test.js: OK');

--- a/tests/deterministic-model-pool-check.js
+++ b/tests/deterministic-model-pool-check.js
@@ -133,6 +133,78 @@ function buildDualGpu36GbHardware() {
     };
 }
 
+function buildDualBlackwellHardware() {
+    return {
+        cpu: { cores: 32, architecture: 'x86_64' },
+        gpu: {
+            model: 'NVIDIA RTX PRO 6000 Blackwell Workstation Edition',
+            vendor: 'NVIDIA',
+            type: 'nvidia',
+            vram: 192,
+            vramPerGPU: 96,
+            gpuCount: 2,
+            isMultiGPU: true,
+            all: [
+                { model: 'NVIDIA RTX PRO 6000 Blackwell Workstation Edition', vram: 96, vendor: 'NVIDIA' },
+                { model: 'NVIDIA RTX PRO 6000 Blackwell Workstation Edition', vram: 96, vendor: 'NVIDIA' }
+            ]
+        },
+        memory: { total: 123 },
+        acceleration: { supports_metal: false, supports_cuda: true, supports_rocm: false },
+        summary: {
+            hardwareTier: 'VERY HIGH',
+            hasDedicatedGPU: true,
+            totalVRAM: 192
+        }
+    };
+}
+
+function buildBlackwellRecommendationPool() {
+    return [
+        {
+            model_identifier: 'blackwell-chat',
+            model_name: 'blackwell-chat',
+            description: 'Synthetic chat family with tiny and high-capacity variants',
+            primary_category: 'chat',
+            context_length: '64K',
+            variants: [
+                { tag: 'blackwell-chat:2b', size: '2b', quantization: 'Q4_0', real_size_gb: 1.6, categories: ['chat'] },
+                { tag: 'blackwell-chat:8b', size: '8b', quantization: 'Q4_0', real_size_gb: 5.1, categories: ['chat'] },
+                { tag: 'blackwell-chat:32b', size: '32b', quantization: 'Q4_0', real_size_gb: 19, categories: ['chat'] },
+                { tag: 'blackwell-chat:70b', size: '70b', quantization: 'Q4_0', real_size_gb: 42, categories: ['chat'] }
+            ],
+            tags: ['blackwell-chat:2b', 'blackwell-chat:8b', 'blackwell-chat:32b', 'blackwell-chat:70b'],
+            use_cases: ['chat']
+        },
+        {
+            model_identifier: 'blackwell-coder',
+            model_name: 'blackwell-coder',
+            description: 'Synthetic coding family for high-end GPU regression',
+            primary_category: 'coding',
+            context_length: '32K',
+            variants: [
+                { tag: 'blackwell-coder:8b', size: '8b', quantization: 'Q4_0', real_size_gb: 5.3, categories: ['coding'] },
+                { tag: 'blackwell-coder:34b', size: '34b', quantization: 'Q4_0', real_size_gb: 20.5, categories: ['coding'] }
+            ],
+            tags: ['blackwell-coder:8b', 'blackwell-coder:34b'],
+            use_cases: ['coding', 'programming']
+        },
+        {
+            model_identifier: 'blackwell-reason',
+            model_name: 'blackwell-reason',
+            description: 'Synthetic reasoning family for high-end GPU regression',
+            primary_category: 'reasoning',
+            context_length: '64K',
+            variants: [
+                { tag: 'blackwell-reason:7b', size: '7b', quantization: 'Q4_0', real_size_gb: 4.8, categories: ['reasoning'] },
+                { tag: 'blackwell-reason:70b', size: '70b', quantization: 'Q4_0', real_size_gb: 43, categories: ['reasoning'] }
+            ],
+            tags: ['blackwell-reason:7b', 'blackwell-reason:70b'],
+            use_cases: ['reasoning', 'math']
+        }
+    ];
+}
+
 function buildFreshnessRegressionPool() {
     return [
         {
@@ -498,6 +570,28 @@ async function runMultiGpu36GbIncludesThirtyBWhenFeasible() {
     );
 }
 
+async function runVeryHighMultiGpuPrefersHighCapacityModels() {
+    const selector = new DeterministicModelSelector();
+    const hardware = buildDualBlackwellHardware();
+    const pool = buildBlackwellRecommendationPool();
+
+    selector.getInstalledModels = async () => [];
+    const recommendations = await selector.getBestModelsForHardware(hardware, pool, { runtime: 'ollama' });
+
+    for (const category of ['general', 'coding', 'reasoning', 'reading']) {
+        const topModel = recommendations[category]?.bestModels?.[0];
+        assert.ok(topModel, `${category} should return a top recommendation`);
+        assert.ok(
+            topModel.size >= 30,
+            `${category} should prefer >=30B models on dual RTX PRO 6000 Blackwell, got ${topModel.model_identifier} (${topModel.size}B)`
+        );
+        assert.ok(
+            /high-capacity/i.test(topModel.reasoning),
+            `${category} rationale should explain high-capacity right-sizing, got: ${topModel.reasoning}`
+        );
+    }
+}
+
 async function runFreshnessPenaltyPrefersRecentModel() {
     const selector = new DeterministicModelSelector();
     const hardware = buildHighEndHardware();
@@ -834,6 +928,7 @@ async function runAll() {
     await runOptimizationProfilesInfluenceRanking();
     await runMultiGpuNormalizationUsesCombinedVram();
     await runMultiGpu36GbIncludesThirtyBWhenFeasible();
+    await runVeryHighMultiGpuPrefersHighCapacityModels();
     await runFreshnessPenaltyPrefersRecentModel();
     await runQuantizedLargeModelCanBeRecommended();
     await runUnified24GbIncludesMidTierWhenFeasible();


### PR DESCRIPTION
## Summary
- keep Windows banner rendering one cell inside the reported width and use a Windows-safe clear sequence
- switch the interactive panel to a compact header on short Windows terminals so the full banner does not overflow the viewport
- add high-capacity right-sizing for very high-end multi-GPU machines so recommendations do not prefer tiny models by default

Refs #86
Refs #88

## Tests
- node tests/cli-interactive-panel.test.js
- node tests/deterministic-model-pool-check.js
- npm test
- npm pack --dry-run