### PR TITLE
Clarify recommendation command modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,6 +573,15 @@ This makes integrated GPUs visible even when the selected runtime backend is sti
 llm-checker recommend
 ```
 
+Use `recommend` as the canonical model-picking command. Other recommendation-like
+commands have narrower roles:
+
+| Command | Role | Expected to match `recommend`? |
+|---------|------|--------------------------------|
+| `recommend` | Canonical deterministic model recommendations by category | Yes, this is the reference output |
+| `check` | Hardware compatibility report with a compatibility-oriented recommendation card | Not exactly; it prioritizes fit/reporting context |
+| `smart-recommend` | Experimental alternate scoring engine used while scoring ideas are evaluated | No; it may differ until it is unified or retired |
+
 Use optimization profiles to steer ranking by intent:
 
 ```bash
@@ -695,7 +704,7 @@ Three scoring systems are available, each optimized for different workflows:
 | `reasoning` | 60% | 10% | 20% | 10% |
 | `multimodal` | 50% | 15% | 20% | 15% |
 
-**Scoring Engine** (used by `smart-recommend` and `search`):
+**Scoring Engine** (experimental &mdash; used by `smart-recommend` and `search`):
 
 | Use Case | Quality | Speed | Fit | Context |
 |----------|:-------:|:-----:|:---:|:-------:|

--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -58,7 +58,7 @@ const calibrationManager = new CalibrationManager();
 
 const COMMAND_HEADER_LABELS = {
     'hw-detect': 'Hardware Detection',
-    'smart-recommend': 'Smart Recommend',
+    'smart-recommend': 'Smart Recommend (Experimental)',
     search: 'Model Search',
     sync: 'Database Sync',
     'mcp-setup': 'Claude MCP Setup',
@@ -77,6 +77,19 @@ const COMMAND_HEADER_LABELS = {
 function showAsciiArt(command) {
     const label = COMMAND_HEADER_LABELS[command] || command;
     renderCommandHeader(label);
+}
+
+const RECOMMENDATION_COMMAND_NOTES = {
+    check: 'Compatibility report: shows hardware fit first. Use `llm-checker recommend` for canonical ranked model picks.',
+    recommend: 'Canonical recommendations: deterministic hardware-aware selector by category.',
+    'smart-recommend': 'Experimental scoring engine: results can differ from `recommend` while this path is being unified.'
+};
+
+function displayRecommendationCommandNote(command) {
+    const note = RECOMMENDATION_COMMAND_NOTES[command];
+    if (!note) return;
+    console.log(chalk.gray(`Recommendation mode: ${note}`));
+    console.log('');
 }
 
 // Function to search Ollama models by use case
@@ -3295,6 +3308,7 @@ Policy scope:
     )
     .action(async (options) => {
         showAsciiArt('check');
+        displayRecommendationCommandNote('check');
         try {
             // Use verbose progress unless explicitly disabled
             const verboseEnabled = options.verbose !== false;
@@ -3851,6 +3865,7 @@ Calibrated routing examples:
     )
     .action(async (options) => {
         showAsciiArt('recommend');
+        displayRecommendationCommandNote('recommend');
         try {
             const verboseEnabled = options.verbose !== false;
             const checker = new (getLLMChecker())({ verbose: verboseEnabled });
@@ -4806,7 +4821,7 @@ program
 
 program
     .command('smart-recommend')
-    .description('Get intelligent model recommendations using the new scoring engine')
+    .description('Experimental recommendations using the alternate scoring engine')
     .option('-u, --use-case <case>', 'Optimize for use case', 'general')
     .option('-l, --limit <n>', 'Maximum number of recommendations', '5')
     .option('--target-tps <n>', 'Target tokens per second', '20')
@@ -4814,8 +4829,19 @@ program
     .option('--include-vision', 'Include vision/multimodal models')
     .option('--include-embeddings', 'Include embedding models')
     .option('-j, --json', 'Output as JSON')
+    .addHelpText(
+        'after',
+        `
+Recommendation engine note:
+  smart-recommend is experimental and may intentionally differ from recommend.
+  Use "llm-checker recommend" for canonical package recommendations.
+`
+    )
     .action(async (options) => {
-        if (!options.json) showAsciiArt('smart-recommend');
+        if (!options.json) {
+            showAsciiArt('smart-recommend');
+            displayRecommendationCommandNote('smart-recommend');
+        }
         const SyncManager = require('../src/data/sync-manager');
         const IntelligentSelector = require('../src/models/intelligent-selector');
         const UnifiedDetector = require('../src/hardware/unified-detector');

--- a/tests/ui-cli-smoke.test.js
+++ b/tests/ui-cli-smoke.test.js
@@ -67,6 +67,18 @@ function run() {
         'recommend help should expose calibrated routing option'
     );
 
+    const smartRecommendHelp = runCli(['smart-recommend', '--help']);
+    const smartRecommendHelpOutput = stripAnsi(smartRecommendHelp.stdout);
+    assert.strictEqual(smartRecommendHelp.status, 0, stripAnsi(smartRecommendHelp.stderr || smartRecommendHelp.stdout));
+    assert.ok(
+        smartRecommendHelpOutput.includes('Experimental recommendations using the alternate scoring engine'),
+        'smart-recommend help should label the command as experimental'
+    );
+    assert.ok(
+        smartRecommendHelpOutput.includes('Use "llm-checker recommend" for canonical package recommendations'),
+        'smart-recommend help should point users to canonical recommend output'
+    );
+
     const calibrateHelp = runCli(['calibrate', '--help']);
     assert.strictEqual(calibrateHelp.status, 0, stripAnsi(calibrateHelp.stderr || calibrateHelp.stdout));
     assert.ok(


### PR DESCRIPTION
## Summary
- label `smart-recommend` as experimental in the CLI header and help text
- add recommendation-mode notes to `check`, `recommend`, and `smart-recommend`
- document that `recommend` is the canonical model-picking command while `check` is compatibility-oriented and `smart-recommend` is an alternate experimental engine

Refs #88

## Tests
- `node -c bin/enhanced_cli.js`
- `node tests/ui-cli-smoke.test.js`
- `node tests/local-features-e2e.test.js`
- `npm audit --audit-level=moderate`
- `npm test`
- `npm pack --dry-run`
