### PR TITLE
Add Windows UI smoke coverage

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -63,3 +63,28 @@ jobs:
           name: policy-audit-reports
           path: .ci-policy/reports
           if-no-files-found: warn
+
+  windows-ui-smoke:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run Windows UI smoke tests
+        shell: pwsh
+        run: |
+          $env:NO_COLOR = '1'
+          $env:LLM_CHECKER_DISABLE_ANIMATION = '1'
+          node tests/cli-interactive-panel.test.js
+          node tests/ui-cli-smoke.test.js
+          node tests/cpu-detector-windows-fallback.test.js


### PR DESCRIPTION
## Summary
- add a Windows GitHub Actions smoke job for UI/render-related tests
- run `cli-interactive-panel`, `ui-cli-smoke`, and `cpu-detector-windows-fallback` on `windows-latest` with PowerShell
- keep the existing Ubuntu policy gate unchanged

Refs #86

## Local validation
- `node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/policy-gate.yml','utf8')); console.log('workflow yaml: OK')"`
- `node tests/cli-interactive-panel.test.js`
- `node tests/ui-cli-smoke.test.js`
- `node tests/cpu-detector-windows-fallback.test.js`

## Note
This does not replace a manual Windows Terminal/PowerShell redraw test, but it gives us Windows CI coverage for the render helpers and CLI smoke path before future UI changes are merged.
