### PR TITLE
fix(hardware): correct GPU-VRAM detection for high-end / multi-GPU machines (#88)

### DIFF
--- a/src/hardware/backends/cuda-detector.js
+++ b/src/hardware/backends/cuda-detector.js
@@ -249,40 +249,65 @@ class CUDADetector {
 
             const lines = gpuData.split('\n');
 
-            for (const line of lines) {
-                const parts = line.split(', ').map(p => p.trim());
+            // Older drivers emit fewer columns (e.g. no power/clocks), and the CSV
+            // separator can be either ", " or "," depending on driver/locale. Split
+            // tolerantly and only require the leading identity + memory columns so a
+            // GPU is never dropped just because optional trailing fields are absent.
+            const toMB = (value) => {
+                const n = parseInt(value, 10);
+                return Number.isFinite(n) ? n : 0;
+            };
+            const toGB = (value) => {
+                const mb = toMB(value);
+                return mb > 0 ? Math.round(mb / 1024) : 0;
+            };
+            const toInt = (value) => {
+                const n = parseInt(value, 10);
+                return Number.isFinite(n) ? n : 0;
+            };
+            const toFloat = (value) => {
+                const n = parseFloat(value);
+                return Number.isFinite(n) ? n : 0;
+            };
 
-                if (parts.length < 10) continue;
+            for (const line of lines) {
+                if (!line || !line.trim()) continue;
+                const parts = line.split(/\s*,\s*/).map(p => p.trim());
+
+                // Need at least index, name, uuid, memory.total to describe a GPU.
+                if (parts.length < 4) continue;
+
+                const memTotalMB = toMB(parts[3]);
 
                 const gpu = {
-                    index: parseInt(parts[0]) || 0,
+                    index: toInt(parts[0]),
                     name: parts[1] || 'Unknown NVIDIA GPU',
                     uuid: parts[2] || null,
                     memory: {
-                        total: Math.round(parseInt(parts[3]) / 1024) || 0,  // Convert MB to GB
-                        free: Math.round(parseInt(parts[4]) / 1024) || 0,
-                        used: Math.round(parseInt(parts[5]) / 1024) || 0
+                        total: toGB(parts[3]),  // Convert MB to GB
+                        free: toGB(parts[4]),
+                        used: toGB(parts[5])
                     },
                     computeMode: parts[6] || 'Default',
                     pcie: {
-                        generation: parseInt(parts[7]) || 0,
-                        width: parseInt(parts[8]) || 0
+                        generation: toInt(parts[7]),
+                        width: toInt(parts[8])
                     },
                     power: {
-                        draw: parseFloat(parts[9]) || 0,
-                        limit: parseFloat(parts[10]) || 0
+                        draw: toFloat(parts[9]),
+                        limit: toFloat(parts[10])
                     },
-                    temperature: parseInt(parts[11]) || 0,
+                    temperature: toInt(parts[11]),
                     utilization: {
-                        gpu: parseInt(parts[12]) || 0,
-                        memory: parseInt(parts[13]) || 0
+                        gpu: toInt(parts[12]),
+                        memory: toInt(parts[13])
                     },
                     clocks: {
-                        current: parseInt(parts[14]) || 0,
-                        max: parseInt(parts[15]) || 0
+                        current: toInt(parts[14]),
+                        max: toInt(parts[15])
                     },
                     capabilities: this.getGPUCapabilities(parts[1]),
-                    speedCoefficient: this.calculateSpeedCoefficient(parts[1], parseInt(parts[3]))
+                    speedCoefficient: this.calculateSpeedCoefficient(parts[1], memTotalMB)
                 };
 
                 result.gpus.push(gpu);
@@ -298,15 +323,18 @@ class CUDADetector {
 
                 const lines = simpleQuery.split('\n');
                 for (let i = 0; i < lines.length; i++) {
-                    const [name, memMB] = lines[i].split(', ').map(p => p.trim());
-                    const memGB = Math.round(parseInt(memMB) / 1024) || 0;
+                    if (!lines[i] || !lines[i].trim()) continue;
+                    const [name, memMB] = lines[i].split(/\s*,\s*/).map(p => p.trim());
+                    const parsedMB = parseInt(memMB, 10);
+                    const memMBSafe = Number.isFinite(parsedMB) ? parsedMB : 0;
+                    const memGB = memMBSafe > 0 ? Math.round(memMBSafe / 1024) : 0;
 
                     result.gpus.push({
                         index: i,
                         name: name || 'NVIDIA GPU',
                         memory: { total: memGB, free: memGB, used: 0 },
                         capabilities: this.getGPUCapabilities(name),
-                        speedCoefficient: this.calculateSpeedCoefficient(name, parseInt(memMB))
+                        speedCoefficient: this.calculateSpeedCoefficient(name, memMBSafe)
                     });
                     result.totalVRAM += memGB;
                 }

--- a/src/hardware/detector.js
+++ b/src/hardware/detector.js
@@ -85,12 +85,16 @@ class HardwareDetector {
         const freeGB = Math.round(memory.free / (1024 ** 3));
         const usedGB = totalGB - freeGB;
 
+        // Guard against a zero/unknown total (some virtualized or sandboxed hosts
+        // report memory.total === 0), which would otherwise make usagePercent NaN.
+        const usagePercent = totalGB > 0 ? Math.round((usedGB / totalGB) * 100) : 0;
+
         return {
             total: totalGB,
             free: freeGB,
             used: usedGB,
             available: Math.round(memory.available / (1024 ** 3)),
-            usagePercent: Math.round((usedGB / totalGB) * 100),
+            usagePercent,
             swapTotal: Math.round(memory.swaptotal / (1024 ** 3)),
             swapUsed: Math.round(memory.swapused / (1024 ** 3)),
             score: this.calculateMemoryScore(totalGB, freeGB)
@@ -558,8 +562,23 @@ class HardwareDetector {
 
         // NVIDIA data-center / workstation
         if (modelLower.includes('gb10') || modelLower.includes('grace blackwell') || modelLower.includes('dgx spark')) return 96;
+
+        // NVIDIA Blackwell / Ada / Hopper workstation & datacenter cards. These are
+        // matched BEFORE the generic "rtx -> 8" fallback so high-VRAM professional
+        // GPUs (e.g. "RTX PRO 6000") are not collapsed to 8GB (issue #88).
+        if (modelLower.includes('rtx pro 6000') || modelLower.includes('rtx 6000 blackwell')) return 96;
+        if (modelLower.includes('rtx 6000 ada') || modelLower.includes('rtx 5000 ada')) return 48;
+        if (modelLower.includes('rtx a6000') || modelLower.includes('a6000')) return 48;
+        if (modelLower.includes('rtx a5000') || modelLower.includes('a5000')) return 24;
+        if (modelLower.includes('l40s') || modelLower.includes('l40')) return 48;
+        if (modelLower.includes('h200')) return 141;
+        if (modelLower.includes('h100')) return 80;
+        if (modelLower.includes('a100') && (modelLower.includes('40gb') || /a100[\s-]?(?:pcie[\s-]?)?40\b/.test(modelLower))) return 40;
+        if (modelLower.includes('a100')) return 80; // A100 defaults to the 80GB SKU
+        if (modelLower.includes('a40')) return 48;
+
         if (modelLower.includes('tesla p100') || modelLower.includes('p100')) return 16;
-        
+
         // NVIDIA RTX 50 series
         if (modelLower.includes('rtx 5090')) return 32;
         if (modelLower.includes('rtx 5080')) return 16;
@@ -640,7 +659,7 @@ class HardwareDetector {
         else score += totalGB * 2;
 
         // Score basado en RAM disponible
-        const freePercent = (freeGB / totalGB) * 100;
+        const freePercent = totalGB > 0 ? (freeGB / totalGB) * 100 : 0;
         if (freePercent > 50) score += 20;
         else if (freePercent > 30) score += 15;
         else if (freePercent > 20) score += 10;
@@ -746,20 +765,34 @@ class HardwareDetector {
         const raw = Number(vram);
         if (!Number.isFinite(raw) || raw <= 0) return 0;
 
-        // Inputs reaching this function are reported by systeminformation / lspci,
-        // which express controller VRAM in megabytes — except very large values,
-        // which are raw bytes on the systems that report that way. No source ever
-        // supplies gigabytes here, so the old "1-80 means GB" heuristic was wrong
-        // (it turned a 64 MB framebuffer into 64 GB of VRAM). Normalize everything
-        // to MB first, then convert once to GB.
+        // Inputs reaching this function come from systeminformation / lspci (which
+        // express controller VRAM in megabytes), from raw byte counts on systems
+        // that report that way, and increasingly from our own curated GB tables
+        // (estimateVRAMFromModel, device-id maps) fed back through here. The unit
+        // is inferred from magnitude:
         //
-        // 1e6 cleanly separates the two units: the largest real VRAM in MB is well
-        // under 1,000,000 (a 192 GB card is ~196,608 MB), while the same card in
-        // bytes is far above it. The previous >100000 byte threshold mis-handled
-        // any card above ~97 GB reported in MB.
-        const mb = raw > 1_000_000 ? raw / (1024 * 1024) : raw;
-
-        return Math.max(0, Math.round(mb / 1024)); // MB -> GB
+        //   > 1e6            -> raw bytes (a 192 GB card is ~2.06e11 bytes, while
+        //                       the same card in MB is ~196,608, well under 1e6).
+        //   >= 1024          -> megabytes (the smallest dedicated framebuffer that
+        //                       still rounds to >=1 GB; this is the systeminformation
+        //                       reporting range, e.g. 8192, 16384, 16368).
+        //   1 <= v <= 256    -> already gigabytes. Real single-GPU VRAM tops out
+        //                       around 192 GB (H200 ~141, B200/MI ~192), so any
+        //                       small integer in this band is a GB value. This is
+        //                       the dead-zone fix for issue #88: normalizeVRAM(96)
+        //                       used to return 0 (treated 96 as 96 MB -> 0 GB).
+        //   257 <= v < 1024  -> sub-gigabyte framebuffer in MB (e.g. a 512 MB
+        //                       aperture) -> rounds to 0/1 GB as before.
+        if (raw > 1_000_000) {
+            return Math.max(0, Math.round(raw / (1024 * 1024 * 1024))); // bytes -> GB
+        }
+        if (raw >= 1024) {
+            return Math.max(0, Math.round(raw / 1024)); // MB -> GB
+        }
+        if (raw <= 256) {
+            return Math.round(raw); // already GB (plausible single-GPU range)
+        }
+        return Math.max(0, Math.round(raw / 1024)); // 257..1023 MB -> GB
     }
     
     /**

--- a/src/hardware/unified-detector.js
+++ b/src/hardware/unified-detector.js
@@ -791,22 +791,27 @@ class UnifiedDetector {
         const num = Number(value);
         if (!Number.isFinite(num) || num <= 0) return 0;
 
-        // Bytes -> GB
-        if (num > 1024 * 1024) {
-            return Math.round(num / (1024 * 1024 * 1024));
+        // Unit inference by magnitude, kept consistent with
+        // HardwareDetector.normalizeVRAM so both detection paths agree:
+        //
+        //   > 1e6            -> raw bytes.
+        //   >= 1024          -> megabytes (systeminformation reporting range).
+        //   1 <= v <= 256    -> already gigabytes. The previous "1..80 means GB"
+        //                       band silently returned 0 for legitimate large GB
+        //                       values, so normalizeFallbackVRAM(192) was 0 — the
+        //                       192 GB box in issue #88 collapsed to nothing. A
+        //                       single GPU realistically tops out around 192 GB.
+        //   257 <= v < 1024  -> sub-gigabyte framebuffer in MB -> rounds to 0/1 GB.
+        if (num > 1_000_000) {
+            return Math.max(0, Math.round(num / (1024 * 1024 * 1024))); // bytes -> GB
         }
-
-        // MB -> GB
         if (num >= 1024) {
-            return Math.round(num / 1024);
+            return Math.max(0, Math.round(num / 1024)); // MB -> GB
         }
-
-        // Likely already GB
-        if (num >= 1 && num <= 80) {
-            return Math.round(num);
+        if (num <= 256) {
+            return Math.round(num); // already GB (plausible single-GPU range)
         }
-
-        return 0;
+        return Math.max(0, Math.round(num / 1024)); // 257..1023 MB -> GB
     }
 
     isIntegratedGPUModel(model) {
@@ -843,6 +848,21 @@ class UnifiedDetector {
         if (lower.includes('rx 7600')) return 8;
         if (lower.includes('rx 6900') || lower.includes('rx 6800')) return 16;
         if (lower.includes('rx 6700')) return 12;
+
+        // NVIDIA workstation / datacenter (Blackwell / Ada / Hopper / Ampere).
+        // Matched BEFORE the consumer RTX entries and the generic fallbacks so a
+        // high-VRAM professional card is not collapsed to a consumer-tier value or
+        // 0 (issue #88: dual "RTX PRO 6000" must reach ~192GB total, not ~16GB).
+        if (lower.includes('rtx pro 6000') || lower.includes('rtx 6000 blackwell')) return 96;
+        if (lower.includes('rtx 6000 ada') || lower.includes('rtx 5000 ada')) return 48;
+        if (lower.includes('rtx a6000') || lower.includes('a6000')) return 48;
+        if (lower.includes('rtx a5000') || lower.includes('a5000')) return 24;
+        if (lower.includes('l40s') || lower.includes('l40')) return 48;
+        if (lower.includes('h200')) return 141;
+        if (lower.includes('h100')) return 80;
+        if (lower.includes('a100') && (lower.includes('40gb') || /a100[\s-]?(?:pcie[\s-]?)?40\b/.test(lower))) return 40;
+        if (lower.includes('a100')) return 80; // A100 defaults to the 80GB SKU
+        if (lower.includes('a40')) return 48;
 
         if (lower.includes('rtx 5090')) return 32;
         if (lower.includes('rtx 4090') || lower.includes('rtx 3090')) return 24;
@@ -953,9 +973,19 @@ class UnifiedDetector {
             summary.bestBackend === 'metal' ||
             (summary.hasIntegratedGPU && !summary.hasDedicatedGPU && summary.integratedSharedMemory > 0)
         ) {
-            return sizeGB <= (summary.effectiveMemory - 2);
+            const effectiveMemory = Number(summary.effectiveMemory);
+            if (!Number.isFinite(effectiveMemory) || effectiveMemory <= 0) return false;
+            return sizeGB <= (effectiveMemory - 2);
         } else {
-            const availableVRAM = useMultiGPU ? summary.totalVRAM : (summary.totalVRAM / summary.gpuCount);
+            const totalVRAM = Number(summary.totalVRAM);
+            if (!Number.isFinite(totalVRAM) || totalVRAM <= 0) return false;
+
+            // Guard the per-GPU divisor: gpuCount can be 0 when the summary was
+            // built without resolved GPU memory, which previously produced
+            // Infinity (totalVRAM / 0) and made any model "fit".
+            const gpuCount = Math.max(1, Number(summary.gpuCount) || 0);
+            const availableVRAM = useMultiGPU ? totalVRAM : (totalVRAM / gpuCount);
+            if (!Number.isFinite(availableVRAM) || availableVRAM <= 0) return false;
             return sizeGB <= (availableVRAM - 2);
         }
     }

--- a/tests/hardware-vram-highend.test.js
+++ b/tests/hardware-vram-highend.test.js
@@ -1,0 +1,186 @@
+/**
+ * High-End / Multi-GPU VRAM Detection Regression Tests (Issue #88)
+ *
+ * Root cause of issue #88: hardware detection under-reported high-end and
+ * multi-GPU machines. A dual RTX PRO 6000 / 192GB box collapsed to ~16GB
+ * because:
+ *   - estimateVRAMFromModel / estimateFallbackVRAM had no entry for
+ *     workstation/datacenter cards, so "RTX PRO 6000" hit the generic
+ *     "rtx -> 8GB" fallback.
+ *   - normalizeVRAM / normalizeFallbackVRAM silently returned 0 for legitimate
+ *     GB-range integers (a GB "dead-zone"), so curated GB values were lost.
+ *   - willModelFit divided totalVRAM by gpuCount with no zero guard, turning
+ *     a zero-GPU summary into Infinity (any model "fit").
+ *
+ * These assertions exercise the real detection code (the actual classes /
+ * methods, not reimplementations).
+ */
+
+const assert = require('assert');
+const HardwareDetector = require('../src/hardware/detector');
+const UnifiedDetector = require('../src/hardware/unified-detector');
+
+/**
+ * (a) Unknown high-VRAM workstation GPUs must resolve to their real VRAM, not
+ *     the generic 8GB RTX fallback.
+ */
+function testWorkstationVramEstimatesAreNotGenericFallback() {
+    const hw = new HardwareDetector();
+    const unified = new UnifiedDetector();
+
+    const rtxProDetector = hw.estimateVRAMFromModel('NVIDIA RTX PRO 6000');
+    const rtxProUnified = unified.estimateFallbackVRAM('NVIDIA RTX PRO 6000');
+
+    assert.strictEqual(rtxProDetector, 96,
+        `RTX PRO 6000 should estimate ~96GB via detector, got ${rtxProDetector}`);
+    assert.strictEqual(rtxProUnified, 96,
+        `RTX PRO 6000 should estimate ~96GB via unified fallback, got ${rtxProUnified}`);
+    assert.notStrictEqual(rtxProDetector, 8,
+        'RTX PRO 6000 must NOT collapse to the generic 8GB RTX fallback');
+
+    // A representative spread of the workstation / datacenter cards added in the fix.
+    assert.strictEqual(hw.estimateVRAMFromModel('NVIDIA RTX 6000 Ada Generation'), 48,
+        'RTX 6000 Ada should estimate 48GB');
+    assert.strictEqual(hw.estimateVRAMFromModel('NVIDIA RTX A6000'), 48,
+        'RTX A6000 should estimate 48GB');
+    assert.strictEqual(hw.estimateVRAMFromModel('NVIDIA A100-SXM4-80GB'), 80,
+        'A100 80GB should estimate 80GB');
+    assert.strictEqual(hw.estimateVRAMFromModel('NVIDIA A100-PCIE-40GB'), 40,
+        'A100 40GB variant should estimate 40GB');
+    assert.strictEqual(hw.estimateVRAMFromModel('NVIDIA H100 80GB PCIe'), 80,
+        'H100 should estimate 80GB');
+    assert.strictEqual(hw.estimateVRAMFromModel('NVIDIA L40S'), 48,
+        'L40S should estimate 48GB');
+
+    // The same workstation cards must be recognised by the unified fallback path too.
+    assert.strictEqual(unified.estimateFallbackVRAM('NVIDIA RTX 6000 Ada Generation'), 48,
+        'RTX 6000 Ada should estimate 48GB via unified fallback');
+    assert.strictEqual(unified.estimateFallbackVRAM('NVIDIA A100-SXM4-80GB'), 80,
+        'A100 80GB should estimate 80GB via unified fallback');
+    assert.strictEqual(unified.estimateFallbackVRAM('NVIDIA H100 80GB PCIe'), 80,
+        'H100 should estimate 80GB via unified fallback');
+    assert.strictEqual(unified.estimateFallbackVRAM('NVIDIA L40S'), 48,
+        'L40S should estimate 48GB via unified fallback');
+}
+
+/**
+ * (b) A simulated dual RTX PRO 6000 system (two dedicated GPUs, no numeric VRAM
+ *     reported by nvidia-smi) must aggregate to a total near 192GB, NOT 16GB.
+ *     Uses the real processGPUInfo aggregation seam.
+ */
+function testDualRtxPro6000AggregatesToFullVram() {
+    const hw = new HardwareDetector();
+
+    const gpu = hw.processGPUInfo(
+        {
+            controllers: [
+                { model: 'NVIDIA RTX PRO 6000', vendor: 'NVIDIA', vram: 0 },
+                { model: 'NVIDIA RTX PRO 6000', vendor: 'NVIDIA', vram: 0 }
+            ],
+            displays: []
+        },
+        // System RAM (192GB box) — irrelevant for dedicated VRAM but realistic.
+        { total: 192 * 1024 ** 3 }
+    );
+
+    assert.strictEqual(gpu.dedicated, true, 'Dual RTX PRO 6000 should be treated as dedicated GPUs');
+    assert.strictEqual(gpu.gpuCount, 2, `Should detect 2 GPUs, got ${gpu.gpuCount}`);
+    assert.strictEqual(gpu.isMultiGPU, true, 'Should flag multi-GPU');
+    assert.strictEqual(gpu.vram, 192,
+        `Dual RTX PRO 6000 should aggregate to 192GB total VRAM, got ${gpu.vram}GB`);
+    assert.ok(gpu.vram >= 180,
+        `Total VRAM must be near 192GB (not the ~16GB regression), got ${gpu.vram}GB`);
+    assert.notStrictEqual(gpu.vram, 16, 'Total VRAM must NOT collapse to the 16GB regression value');
+}
+
+/**
+ * (c) Normalization must preserve plausible GB integers (no GB dead-zone), while
+ *     still handling bytes and MB inputs, and stay consistent across both paths.
+ */
+function testNormalizationHasNoGbDeadZone() {
+    const hw = new HardwareDetector();
+    const unified = new UnifiedDetector();
+
+    // The exact dead-zone values from issue #88.
+    assert.strictEqual(hw.normalizeVRAM(96), 96, 'normalizeVRAM(96) must be 96, not 0');
+    assert.strictEqual(unified.normalizeFallbackVRAM(192), 192, 'normalizeFallbackVRAM(192) must be 192, not 0');
+
+    // Other plausible GB integers are preserved on both paths.
+    assert.strictEqual(hw.normalizeVRAM(48), 48, 'normalizeVRAM(48) must be 48');
+    assert.strictEqual(unified.normalizeFallbackVRAM(48), 48, 'normalizeFallbackVRAM(48) must be 48');
+    assert.strictEqual(hw.normalizeVRAM(192), 192, 'normalizeVRAM(192) must be 192');
+    assert.strictEqual(unified.normalizeFallbackVRAM(96), 96, 'normalizeFallbackVRAM(96) must be 96');
+
+    // Bytes and MB inputs still normalize correctly (no regression).
+    assert.strictEqual(hw.normalizeVRAM(16384), 16, 'normalizeVRAM(16384 MB) must be 16GB');
+    assert.strictEqual(hw.normalizeVRAM(25769803776), 24, 'normalizeVRAM(24GB in bytes) must be 24GB');
+    assert.strictEqual(unified.normalizeFallbackVRAM(16384), 16, 'normalizeFallbackVRAM(16384 MB) must be 16GB');
+    assert.strictEqual(unified.normalizeFallbackVRAM(206158430208), 192,
+        'normalizeFallbackVRAM(192GB in bytes) must be 192GB');
+
+    // The two functions agree on representative inputs.
+    for (const value of [48, 96, 192, 16384, 25769803776]) {
+        assert.strictEqual(hw.normalizeVRAM(value), unified.normalizeFallbackVRAM(value),
+            `normalizeVRAM and normalizeFallbackVRAM should agree for ${value}`);
+    }
+}
+
+/**
+ * (d) willModelFit must NOT divide-by-zero into a false "fits": a 50GB model on a
+ *     summary with gpuCount 0 and totalVRAM 0 must return false.
+ */
+function testWillModelFitGuardsZeroGpuCount() {
+    const unified = new UnifiedDetector();
+
+    unified.cache = {
+        summary: {
+            bestBackend: 'cuda',
+            totalVRAM: 0,
+            gpuCount: 0,
+            effectiveMemory: 0,
+            hasIntegratedGPU: false,
+            hasDedicatedGPU: true,
+            integratedSharedMemory: 0
+        }
+    };
+
+    assert.strictEqual(unified.willModelFit(50, false), false,
+        'willModelFit(50, single-GPU) must be false when gpuCount=0 and totalVRAM=0 (no divide-by-zero Infinity)');
+    assert.strictEqual(unified.willModelFit(50, true), false,
+        'willModelFit(50, multi-GPU) must be false when totalVRAM=0');
+
+    // Sanity: a genuinely large VRAM pool still fits a 50GB model.
+    unified.cache = {
+        summary: {
+            bestBackend: 'cuda',
+            totalVRAM: 192,
+            gpuCount: 2,
+            effectiveMemory: 192,
+            hasIntegratedGPU: false,
+            hasDedicatedGPU: true,
+            integratedSharedMemory: 0
+        }
+    };
+    assert.strictEqual(unified.willModelFit(50, true), true,
+        'willModelFit(50) should be true on a 192GB multi-GPU pool');
+}
+
+function run() {
+    testWorkstationVramEstimatesAreNotGenericFallback();
+    testDualRtxPro6000AggregatesToFullVram();
+    testNormalizationHasNoGbDeadZone();
+    testWillModelFitGuardsZeroGpuCount();
+    console.log('✅ hardware-vram-highend.test.js passed');
+}
+
+if (require.main === module) {
+    try {
+        run();
+    } catch (error) {
+        console.error('❌ hardware-vram-highend.test.js failed');
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+module.exports = { run };

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -13,6 +13,7 @@ const TESTS = [
     { name: 'Hardware detector regression', file: 'hardware-detector-regression.js', category: 'Hardware' },
     { name: 'Hardware tier consistency', file: 'hardware-tier-consistency.test.js', category: 'Hardware' },
     { name: 'ROCm VRAM parsing regression', file: 'rocm-vram-parsing.test.js', category: 'Hardware' },
+    { name: 'High-end / multi-GPU VRAM detection', file: 'hardware-vram-highend.test.js', category: 'Hardware' },
     { name: 'CPU detector Windows fallback', file: 'cpu-detector-windows-fallback.test.js', category: 'Hardware' },
     { name: 'Termux platform support', file: 'termux-platform-support.test.js', category: 'Hardware' },
     { name: 'Token speed estimation', file: 'token-speed-estimation.test.js', category: 'Performance' },


### PR DESCRIPTION
## Why
Root cause behind part of #88: on a dual **RTX PRO 6000 / 192GB** box the detector collapses the VRAM to ~16GB, which feeds the scorer a tiny memory budget and makes small models win. The detector under-reports VRAM in several ways.

## What changed
- **Unknown high-VRAM GPUs no longer collapse to a generic 8GB.** Added accurate workstation/datacenter entries (RTX PRO 6000 = 96, RTX 6000 Ada = 48, A6000/A5000, A100 80/40, H100/H200, L40/L40S, A40) to both `estimateVRAMFromModel` (`detector.js`) and `estimateFallbackVRAM` (`unified-detector.js`), ordered specific-before-generic.
- **Fixed the GB dead-zone in VRAM normalization.** `normalizeVRAM(96)` returned `0` (treated 96 as MB) and `normalizeFallbackVRAM(192)` returned `0` (values 81–1023 fell through every branch). Plausible GB integers are now preserved; both functions use consistent unit assumptions. Existing byte/MB normalization assertions still pass.
- **Guarded `willModelFit` divide-by-zero.** `totalVRAM / gpuCount` returned `Infinity` when `gpuCount === 0`, so *any* model "fit". Now uses `Math.max(1, gpuCount)` + finite/positive guards.
- **`nvidia-smi` CSV parsing hardened.** Tolerant separator, no longer drops a GPU when optional trailing columns (power/clocks) are missing, and added `Number.isFinite` guards on every numeric field.
- **`processMemoryInfo` NaN guard** when `memory.total` is 0 (VMs/containers).

## Validation
- New integration test `tests/hardware-vram-highend.test.js` asserts (via the real detection code): RTX PRO 6000 → ~96GB (not 8), a simulated dual-card system aggregates to ~192GB (not 16), `normalizeVRAM(96)===96` / `normalizeFallbackVRAM(192)===192`, and `willModelFit` returns `false` (not an Infinity-backed `true`) when `gpuCount`/`totalVRAM` are 0.
- Full suite: **36/36 passing** (35 existing + 1 new). No existing test modified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)