### PR TITLE
fix(registry): size MoE models by total params; regenerate seed DB

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -7,10 +7,19 @@ Changelog
 Adds a packaged multi-source model registry (Hugging Face + Ollama + GPT4All)
 and wires it into the recommendation flow. Full suite green at 44/44.
 
-- Registry: packaged snapshot of 3,259 repos / 33,729 artifacts seeded from
+- Registry: packaged snapshot of ~3,259 repos / ~33,736 artifacts seeded from
   Hugging Face, Ollama, and GPT4All, with exact install/download commands
   (`hf download ...`, `ollama pull ...`). New `registry-sync`/`registry-search`
   /`registry-recommend` CLI surface.
+- MoE memory sizing is now correct: the recommender sizes Mixture-of-Experts
+  models (e.g. `Mixtral-8x7B`, `Qwen3-397B-A17B`) by their TOTAL parameter count
+  (all experts are resident under Ollama / Metal / vLLM), re-deriving the total
+  from the model name so a stale/under-reported DB value can never make a huge
+  model falsely "fit" small hardware. Active params drive speed only — they no
+  longer switch memory onto a sparse-offload assumption. The packaged seed DB was
+  regenerated so stored MoE totals are correct (Mixtral-8x7B 7B→56B,
+  Qwen3.5-397B-A17B 17B→397B total / 17B active). Test:
+  `tests/model-registry-param-parsing.test.js`.
 - `recommend` (and the `check` recommendation card) now source candidates from
   the registry via the canonical deterministic scoring core, with `--runtime auto`
   plus Ollama/vLLM/MLX/llama.cpp/Transformers targeting; falls back to the Ollama

--- a/src/data/registry-ingestors.js
+++ b/src/data/registry-ingestors.js
@@ -323,9 +323,13 @@ function normalizeHuggingFaceModel(model) {
         }
     };
 
-    const repoParamsB =
+    const nameTotalB = parseParamsB(repoId, tags.join(' '));
+    const metadataParamsB =
         sumSafetensorsParams(model.safetensors) ||
-        parseParamsB(model.config?.num_parameters, model.cardData?.params, repoId, tags.join(' '));
+        parseParamsB(model.config?.num_parameters, model.cardData?.params);
+    // Prefer the larger of metadata vs the MoE-aware name total, so an MoE whose
+    // safetensors/config under-reports (or is absent) still stores the full total.
+    const repoParamsB = Math.max(metadataParamsB || 0, nameTotalB || 0) || null;
     const activeParamsB = parseActiveParamsB(repoId, tags.join(' '));
     const contextLength = Number(
         model.config?.max_position_embeddings ||
@@ -357,7 +361,7 @@ function normalizeHuggingFaceModel(model) {
             format,
             quantization,
             precision,
-            parameter_count_b: parseParamsB(filename) || repoParamsB,
+            parameter_count_b: Math.max(parseParamsB(filename) || 0, repoParamsB || 0) || null,
             active_parameter_count_b: activeParamsB,
             size_bytes: sizeBytes,
             size_gb: bytesToGB(sizeBytes),
@@ -513,7 +517,7 @@ function normalizeOllamaRows(model, variant) {
             format: 'ollama',
             quantization: variant.quant || inferQuantization(tag),
             precision: inferPrecision(variant.quant, tag),
-            parameter_count_b: Number(variant.params_b) || parseParamsB(tag),
+            parameter_count_b: Math.max(Number(variant.params_b) || 0, parseParamsB(tag) || 0) || null,
             active_parameter_count_b: null,
             size_bytes: null,
             size_gb: Number(variant.size_gb) || null,

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -33,6 +33,26 @@ function parseParamsB(...values) {
     return null;
 }
 
+// Active-param naming, e.g. "...-A17B" in "Qwen3-397B-A17B".
+function parseActiveParamsFromName(...values) {
+    for (const value of values) {
+        const m = String(value || '').match(/(?:^|[-_\s/])a(\d+(?:\.\d+)?)\s*b\b/i);
+        if (m) {
+            const v = Number(m[1]);
+            if (Number.isFinite(v) && v > 0) return v;
+        }
+    }
+    return null;
+}
+
+// Detect Mixture-of-Experts naming so we size by total params (memory) and can
+// apply MoE speed assumptions. Covers "8x7B", "397B-A17B", "moe", and Mixtral.
+function isMoEName(...values) {
+    return values.some((value) =>
+        /(\d+\s*x\s*\d+(?:\.\d+)?\s*b\b)|(\d+(?:\.\d+)?\s*b[-_\s]*a\d)|\bmoe\b|mixtral/i.test(String(value || ''))
+    );
+}
+
 function inferFamily(identifier = '') {
     const text = String(identifier || '').toLowerCase();
     const families = [
@@ -101,17 +121,42 @@ function artifactToSelectorModel(row) {
         : (row.artifact_name || row.filename || row.canonical_model_id || row.repo_id);
     const displayName = row.canonical_model_id || row.repo_display_name || identifier;
     const quant = normalizeQuantization(row);
-    const paramsB = parseParamsB(
-        row.active_parameter_count_b,
-        row.parameter_count_b,
-        row.artifact_name,
-        row.filename,
-        row.canonical_model_id,
-        row.repo_id
-    );
+
+    // MEMORY sizing must use the TOTAL parameter count (for MoE, ALL experts are
+    // resident), never the active count. We re-derive the total from the model
+    // name (MoE-aware) and take the max with the stored column, so a stale or
+    // under-reported DB value (an MoE saved as one expert, or an active-param
+    // count) can never make a huge model look tiny and "fit" small hardware.
+    const nameStrings = [row.artifact_name, row.filename, row.canonical_model_id, row.repo_id];
+    const storedTotalB = parseParamsB(row.parameter_count_b);
+    const nameTotalB = parseParamsB(...nameStrings);
+    const totalParamsB = Math.max(storedTotalB || 0, nameTotalB || 0) || null;
+    const activeParamsB = parseParamsB(row.active_parameter_count_b) || parseActiveParamsFromName(...nameStrings);
+    const isMoE = isMoEName(...nameStrings)
+        || (Number.isFinite(activeParamsB) && Number.isFinite(totalParamsB) && activeParamsB < totalParamsB);
+
+    // The sizing param is the total; fall back to the active count only if no
+    // total can be determined at all.
+    const paramsB = Number.isFinite(totalParamsB) && totalParamsB > 0
+        ? totalParamsB
+        : parseParamsB(row.active_parameter_count_b);
 
     if (!identifier || !Number.isFinite(paramsB) || paramsB <= 0) {
         return null;
+    }
+
+    // Flag MoE and carry the TOTAL parameter count so memory is sized by the
+    // full weight set (all experts are resident under Ollama / Metal / vLLM).
+    // We deliberately do NOT set activeParamsB here: that would switch the memory
+    // model to "sparse inference" (sizing by active params), which would let a
+    // 397B-A17B model falsely "fit" ~11GB. Active params drive speed only, and
+    // sparse offload is not how the local runtimes this tool targets behave, so
+    // we stay conservative on memory.
+    const moeFields = {};
+    if (isMoE && Number.isFinite(totalParamsB) && totalParamsB > 0) {
+        moeFields.isMoE = true;
+        moeFields.totalParamsB = totalParamsB;
+        moeFields.total_params_b = totalParamsB;
     }
 
     const runtimeSupport = toArray(row.runtime_support);
@@ -138,6 +183,7 @@ function artifactToSelectorModel(row) {
         model_identifier: identifier,
         family: inferFamily(`${displayName} ${identifier}`),
         paramsB,
+        ...moeFields,
         quant,
         availableQuantizations: [quant],
         sizeGB: Number.isFinite(sizeGB) && sizeGB > 0 ? sizeGB : undefined,

--- a/tests/model-registry-param-parsing.test.js
+++ b/tests/model-registry-param-parsing.test.js
@@ -47,6 +47,54 @@ function testRecommenderMoEParsing() {
     });
     assert.ok(model, 'MoE artifact should map to a selector model');
     assert.strictEqual(model.paramsB, 56, 'recommender should size 8x7B as 56B total');
+    assert.strictEqual(model.isMoE, true, '8x7B should be flagged MoE');
+    assert.strictEqual(model.totalParamsB, 56, 'totalParamsB carries the full MoE total');
+}
+
+function testRecommenderActiveParamTotalSizing() {
+    // "397B-A17B" = 397B total / 17B active. Memory must be sized by the TOTAL.
+    const model = artifactToSelectorModel({
+        source_id: 'huggingface',
+        repo_id: 'Qwen/Qwen3-397B-A17B',
+        canonical_model_id: 'Qwen/Qwen3-397B-A17B',
+        artifact_name: 'Qwen3-397B-A17B'
+    });
+    assert.ok(model, 'active-param MoE should map');
+    assert.strictEqual(model.paramsB, 397, 'sizing param must be the 397B total, not the 17B active');
+    assert.strictEqual(model.totalParamsB, 397, 'totalParamsB = 397');
+    assert.strictEqual(model.isMoE, true, 'flagged MoE');
+    // activeParamsB must NOT be set on the model: setting it would switch the
+    // selector to sparse-inference memory and let a 397B model falsely "fit".
+    assert.strictEqual(model.activeParamsB, undefined, 'activeParamsB must not drive memory sizing');
+
+    // The critical guard: even when a STALE DB stored the active count (17) in
+    // parameter_count_b, the name re-derivation must still size it as 397B.
+    const stale = artifactToSelectorModel({
+        source_id: 'huggingface',
+        repo_id: 'Qwen/Qwen3-397B-A17B',
+        canonical_model_id: 'Qwen/Qwen3-397B-A17B',
+        artifact_name: 'Qwen3-397B-A17B',
+        parameter_count_b: 17
+    });
+    assert.strictEqual(stale.paramsB, 397, 'stale active-param DB value must not shrink the model');
+}
+
+function testHugeMoEDoesNotFitSmallHardware() {
+    // End-to-end memory guard: a 397B MoE must NOT be reported as fitting a 24GB Mac.
+    const DeterministicModelSelector = require('../src/models/deterministic-selector');
+    const selector = new DeterministicModelSelector();
+    const model = artifactToSelectorModel({
+        source_id: 'huggingface',
+        repo_id: 'Qwen/Qwen3-397B-A17B',
+        canonical_model_id: 'Qwen/Qwen3-397B-A17B',
+        artifact_name: 'Qwen3-397B-A17B',
+        parameter_count_b: 17,
+        runtime_support: ['vllm']
+    });
+    const breakdown = selector.estimateMemoryBreakdown(model, 'Q4_K_M', 8192);
+    // 397B at Q4 is hundreds of GB; it must be far above a 24GB budget.
+    assert.ok(breakdown.requiredGB > 100,
+        `397B MoE should require >100GB, got ${breakdown.requiredGB.toFixed(1)}GB (memory must use total params)`);
 }
 
 function testGpt4AllTrailingSlashName() {
@@ -100,6 +148,8 @@ async function run() {
     testMoEParamParsing();
     testContextTokenNotMisreadAsParams();
     testRecommenderMoEParsing();
+    testRecommenderActiveParamTotalSizing();
+    testHugeMoEDoesNotFitSmallHardware();
     testGpt4AllTrailingSlashName();
     await testRuntimeLikeEscape();
     console.log('model-registry-param-parsing.test.js: OK');


### PR DESCRIPTION
## Why
Found while validating 3.7.0 locally: the registry could recommend Mixture-of-Experts models that **cannot physically fit** the user's hardware. On a 24 GB Mac, `--runtime vllm` reasoning ranked `Qwen/Qwen3.5-397B-A17B` **#1**, claiming it *"fits in 11 GB"*, and Mixtral 8x7B was stored/sized as **7B / 2.1 GB**.

## Root causes
1. **The recommender sized memory by the stored/active param count.** An MoE saved as a single expert (`Mixtral-8x7B` → 7B) or by its active count (`397B-A17B` → 17B) looked tiny. It now sizes by the **TOTAL**, re-derived from the model name (MoE-aware) and `max`'d with the stored column — so a stale/under-reported DB value can never shrink a model.
2. **Setting `activeParamsB` switched the selector to a "sparse inference" memory model** (sizing by active params), which is false for Ollama / Metal / vLLM — they keep all experts resident. We now flag MoE and carry `totalParamsB` but **not** `activeParamsB`, so memory stays conservative (active params remain a name-derived speed signal only).

## Also
- The **ingestor** now stores the MoE total in `parameter_count_b` (HF + Ollama paths), taking `max(metadata/safetensors, MoE-aware name total)`.
- The **packaged seed DB was regenerated** so stored MoE totals are correct: `Mixtral-8x7B` 7B→**56B**, `Qwen3.5-397B-A17B` 17B→**397B total / 17B active**. Dense models unchanged (70B→70B). Snapshot: 3 sources, ~3,259 repos, ~33,736 artifacts.

## Validation
- New assertions in `tests/model-registry-param-parsing.test.js`, including an **end-to-end memory check** that a 397B MoE requires >100 GB (cannot fit a 24 GB Mac).
- Verified live: vLLM reasoning now tops out at `gpt-oss-20b` ("fits in 13.4/17 GB") and `Qwen3-14B` — no more impossible "fits".
- Full suite **44/44**. Changes are registry-scoped; the core deterministic selector and its tests are untouched.

> Follow-up to #99 (still unpublished 3.7.0). Pre-existing cosmetic dedup/sharding noise (near-identical quant/shard rows) is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)