### PR TITLE
fix(scoring): MoE/variant/multi-GPU memory sizing + recommendation hardening

### DIFF
--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -290,8 +290,13 @@ const ALLOWED_CLI_COMMANDS = new Set([
   "sync",
   "search",
   "smart-recommend",
+  "registry-sync",
+  "registry-search",
+  "registry-recommend",
   "hw-detect",
 ]);
+
+export { ALLOWED_CLI_COMMANDS };
 
 // ============================================================================
 // MCP SERVER

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,6 +1,32 @@
 Changelog
 =========
 
+3.7.2 — Memory-sizing & Recommendation Hardening (2026-06-20)
+------------------------------------------------------------
+
+A bug-hunt pass (multi-area review) fixing several causes of FALSE "fits" and
+dropped picks. Full suite 46/46; new `tests/selector-memory-sizing.test.js` plus
+added cases across the registry/MCP tests.
+
+- MoE weight memory is sized by the TOTAL parameter count, and a real observed
+  artifact size ALWAYS wins — the "sparse inference" path that sized MoE weights
+  by active params (making a 236B MoE look ~14GB and "fit" a 16GB box) is gone.
+  This fixes the Ollama-catalog path that the 3.7.0 registry fix didn't cover.
+- A size-unknown Ollama variant (e.g. `:latest`) no longer inherits `model_sizes[0]`:
+  it's disambiguated by its own artifact size, so `qwen3:latest` is sized ~9B
+  instead of 30B and stops poisoning the real `qwen3:30b` size map (a 19GB model
+  that was falsely "fitting" 16GB).
+- Multi-GPU VRAM is no longer double-counted: a bare total `vramGB` is treated as
+  the box total (a 2x24=48GB box stays 48GB, not 96GB).
+- `filterByCategory` tolerates malformed pool rows instead of throwing (one bad
+  row used to silently empty a whole category).
+- Registry recommendations: source diversity no longer drops several genuine top
+  picks to seed obscure sources (most slots stay best-by-score); a sharded HF
+  weight file's per-shard size is no longer used as the whole-model size; and
+  unknown-param models with the same name no longer collapse into one.
+- MCP: `registry-sync` / `registry-search` / `registry-recommend` are now in the
+  `cli_exec` allowlist (and the allowlist is exported + tested).
+
 3.7.1 — Registry Recommendation Diversity (2026-06-20)
 ------------------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.7.1",
+      "version": "3.7.2",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.7.1",
+  "version": "3.7.2",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -173,7 +173,12 @@ function artifactToSelectorModel(row) {
         .filter(Boolean)
         .map((tag) => String(tag).toLowerCase());
 
-    const sizeGB = Number(row.size_gb);
+    // A sharded weight file's size is only ONE shard, not the whole model. Don't
+    // let it stand in for the model's memory (that made a 56B model look like
+    // ~4.6GB and "fit" tiny hardware); leave size unset so memory estimates from
+    // the (total) parameter count instead.
+    const rawSizeGB = Number(row.size_gb);
+    const sizeGB = (!shardedFile && Number.isFinite(rawSizeGB) && rawSizeGB > 0) ? rawSizeGB : NaN;
     const sizeByQuant = Number.isFinite(sizeGB) && sizeGB > 0
         ? { [quant]: sizeGB }
         : {};
@@ -255,8 +260,16 @@ function modelDiversityKey(candidate) {
         .replace(/:.*$/, '')   // drop an ollama :tag
         .replace(/\s+/g, ' ')
         .trim();
-    const params = Number(meta.paramsB) > 0 ? Math.round(Number(meta.paramsB) * 10) / 10 : 'na';
-    return `${name}|${params}`;
+    const p = Number(meta.paramsB);
+    if (Number.isFinite(p) && p > 0) {
+        return `${name}|${Math.round(p * 10) / 10}`;
+    }
+    // Params unknown: do NOT bucket every unknown-size model of the same name
+    // together (that silently drops distinct models / sources). Keep them apart by
+    // source + identifier.
+    const src = String(meta.source || '').toLowerCase();
+    const id = String(meta.model_identifier || meta.name || '').toLowerCase();
+    return `${name}|na|${src}|${id}`;
 }
 
 // Collapse quant/shard/tag variants of the same model to a single best-scoring
@@ -279,27 +292,31 @@ function applySourceDiversity(distinctSorted, limit) {
     const list = Array.isArray(distinctSorted) ? distinctSorted : [];
     if (list.length === 0) return [];
     const max = Number(limit) > 0 ? Number(limit) : 10;
+    if (list.length <= max) return list.slice(0, max);
     const topScore = Number(list[0].score) || 0;
 
-    const seeds = [];
-    const seenSource = new Set();
-    for (const c of list) {
-        const src = (c.meta && c.meta.source) || 'unknown';
-        if (seenSource.has(src)) continue;
-        const score = Number(c.score) || 0;
-        if (score >= SOURCE_DIVERSITY_FLOOR && score >= topScore - SOURCE_DIVERSITY_MARGIN) {
-            seeds.push(c);
-            seenSource.add(src);
-        }
-    }
+    // Reserve most slots for the genuine best-by-score so diversity can never
+    // displace several real top picks for several obscure sources. Only the tail
+    // (~40% of slots) is used to surface competitive alternate sources.
+    const guaranteed = Math.max(1, Math.ceil(max * 0.6));
+    const result = list.slice(0, guaranteed);
+    const chosen = new Set(result);
+    const present = new Set(result.map((c) => (c.meta && c.meta.source) || 'unknown'));
 
-    const chosen = new Set(seeds);
-    const result = [...seeds];
-    for (const c of list) {
-        if (result.length >= max) break;
-        if (chosen.has(c)) continue;
-        result.push(c);
-        chosen.add(c);
+    while (result.length < max) {
+        // Prefer the best candidate from a not-yet-shown source that is still
+        // competitive (within margin + above floor); otherwise the next best overall.
+        let pick = list.find((c) => {
+            if (chosen.has(c)) return false;
+            const src = (c.meta && c.meta.source) || 'unknown';
+            const score = Number(c.score) || 0;
+            return !present.has(src) && score >= SOURCE_DIVERSITY_FLOOR && score >= topScore - SOURCE_DIVERSITY_MARGIN;
+        });
+        if (!pick) pick = list.find((c) => !chosen.has(c));
+        if (!pick) break;
+        result.push(pick);
+        chosen.add(pick);
+        present.add((pick.meta && pick.meta.source) || 'unknown');
     }
     return result
         .sort((a, b) => (Number(b.score) || 0) - (Number(a.score) || 0))

--- a/src/models/deterministic-selector.js
+++ b/src/models/deterministic-selector.js
@@ -243,13 +243,12 @@ class DeterministicModelSelector {
             directVRAM ??
             0;
 
-        // Multi-GPU fallback when only per-GPU memory is known.
-        if (!explicitTotalVRAM && gpuCount > 1) {
-            if (vramPerGPU) {
-                vramGB = vramPerGPU * gpuCount;
-            } else if (directVRAM && Boolean(gpu.isMultiGPU || input.isMultiGPU)) {
-                vramGB = Math.max(directVRAM, directVRAM * gpuCount);
-            }
+        // Multi-GPU: only scale up when memory is known to be PER-GPU (vramPerGPU).
+        // A bare `vram`/`vramGB` is treated as the box total and never multiplied,
+        // so we don't double an already-total figure and falsely "fit" a model
+        // (e.g. a 2x24=48GB box must stay 48GB, not become 96GB).
+        if (!explicitTotalVRAM && gpuCount > 1 && vramPerGPU) {
+            vramGB = vramPerGPU * gpuCount;
         }
 
         let gpuType = gpu.type;
@@ -1152,6 +1151,17 @@ class DeterministicModelSelector {
             return explicitParams;
         }
 
+        // Use the variant's OWN artifact size to DISAMBIGUATE the model-level size
+        // list. A size-unknown variant (e.g. `:latest`) must not blindly inherit
+        // model_sizes[0]: for qwen3 (model_sizes ["30b","235b"]) that mislabeled a
+        // small qwen3:latest as 30B and poisoned the real qwen3:30b size map, making
+        // a 19GB model falsely "fit" a 16GB machine.
+        const artifactSizeGB = this.extractVariantSizeGB(variant, null);
+        const artifactParamsB =
+            (!this.isCloudVariantTag(variant.tag) && Number.isFinite(artifactSizeGB) && artifactSizeGB > 0)
+                ? this.inferParamsFromArtifactSizeGB(artifactSizeGB, quant)
+                : null;
+
         const metadataCandidates = this.extractParameterCandidates(
             ollamaModel.model_sizes,
             ollamaModel.parameters,
@@ -1159,12 +1169,23 @@ class DeterministicModelSelector {
             ollamaModel.parameter_count
         );
         if (metadataCandidates.length > 0) {
+            if (Number.isFinite(artifactParamsB) && artifactParamsB > 0) {
+                // Pick the listed size CLOSEST to what this variant's own artifact
+                // implies; if even the closest is far off, trust the artifact size.
+                let closest = metadataCandidates[0];
+                let bestDiff = Math.abs(closest - artifactParamsB);
+                for (const cand of metadataCandidates) {
+                    const diff = Math.abs(cand - artifactParamsB);
+                    if (diff < bestDiff) { bestDiff = diff; closest = cand; }
+                }
+                const tolerance = Math.max(2, closest * 0.5);
+                return bestDiff <= tolerance ? closest : artifactParamsB;
+            }
             return metadataCandidates[0];
         }
 
-        const artifactSizeGB = this.extractVariantSizeGB(variant, null);
-        if (!this.isCloudVariantTag(variant.tag) && Number.isFinite(artifactSizeGB) && artifactSizeGB > 0) {
-            return this.inferParamsFromArtifactSizeGB(artifactSizeGB, quant);
+        if (Number.isFinite(artifactParamsB) && artifactParamsB > 0) {
+            return artifactParamsB;
         }
 
         const modelArtifactSizeGB = this.extractArtifactSizeGBFromValue(ollamaModel.main_size);
@@ -1512,28 +1533,35 @@ class DeterministicModelSelector {
                 return false;
             }
 
+            // Guard against malformed external pool rows (a missing tags/modalities
+            // /name field used to throw and silently nuke the whole category).
+            const tags = Array.isArray(model.tags) ? model.tags : [];
+            const modalities = Array.isArray(model.modalities) ? model.modalities : [];
+            const name = String(model.name || model.model_identifier || '').toLowerCase();
+            const paramsB = Number(model.paramsB) || 0;
+
             switch (category) {
                 case 'coding':
-                    return model.tags.some(tag => ['coder', 'code', 'instruct'].includes(tag)) ||
-                           model.name.toLowerCase().includes('code');
-                           
+                    return tags.some(tag => ['coder', 'code', 'instruct'].includes(tag)) ||
+                           name.includes('code');
+
                 case 'multimodal':
-                    return model.modalities.includes('vision') ||
-                           model.tags.includes('vision');
-                           
+                    return modalities.includes('vision') ||
+                           tags.includes('vision');
+
                 case 'embeddings':
-                    return model.tags.includes('embedding') ||
-                           model.tags.includes('embeddings') ||
-                           model.name.toLowerCase().includes('embed') ||
-                           model.name.toLowerCase().includes('bge-') ||
-                           model.name.toLowerCase().includes('nomic-embed') ||
-                           model.name.toLowerCase().includes('all-minilm') ||
+                    return tags.includes('embedding') ||
+                           tags.includes('embeddings') ||
+                           name.includes('embed') ||
+                           name.includes('bge-') ||
+                           name.includes('nomic-embed') ||
+                           name.includes('all-minilm') ||
                            model.specialization === 'embeddings';
-                           
+
                 case 'reasoning':
-                    return model.tags.includes('instruct') || 
-                           model.paramsB >= 7; // Prefer larger models for reasoning
-                           
+                    return tags.includes('instruct') ||
+                           paramsB >= 7; // Prefer larger models for reasoning
+
                 default: // general, reading, summarization
                     return true; // Most models can handle these
             }
@@ -1711,15 +1739,19 @@ class DeterministicModelSelector {
             : (Number.isFinite(directVariantMatch) && directVariantMatch > 0 ? directVariantMatch : null);
 
         const parameterProfile = this.resolveMemoryParameterProfile(model);
-        const modeledWeightGB = parameterProfile.effectiveParamsB * bpp;
-        const preferSparseInferenceParams =
-            parameterProfile.isMoE &&
-            (parameterProfile.assumptionSource === 'moe_active_metadata' ||
-                parameterProfile.assumptionSource === 'moe_derived_expert_ratio');
-        const useObservedArtifactSize =
-            !preferSparseInferenceParams &&
-            Number.isFinite(observedWeightGB) &&
-            observedWeightGB > 0;
+        // Weight memory must account for ALL resident parameters. For MoE under
+        // Ollama / Metal / vLLM every expert is resident, so size the weights by
+        // the TOTAL parameter count (not the active count). Active params drive
+        // speed and KV-cache only. Sizing weights by active params used to make a
+        // 236B MoE look like ~14GB and falsely "fit" small hardware.
+        const weightParamsB =
+            parameterProfile.isMoE && Number.isFinite(parameterProfile.totalParamsB) && parameterProfile.totalParamsB > 0
+                ? parameterProfile.totalParamsB
+                : parameterProfile.effectiveParamsB;
+        const modeledWeightGB = weightParamsB * bpp;
+        // A real observed artifact size always wins for weight memory — never let
+        // an MoE "sparse inference" assumption discard a measured on-disk size.
+        const useObservedArtifactSize = Number.isFinite(observedWeightGB) && observedWeightGB > 0;
         const modelMemGB = useObservedArtifactSize ? observedWeightGB : modeledWeightGB;
         const effectiveCtx = Number.isFinite(Number(ctx)) && Number(ctx) > 0 ? Number(ctx) : 4096;
 
@@ -1729,9 +1761,10 @@ class DeterministicModelSelector {
 
         // Runtime overhead (Metal/CUDA context, buffers)
         const runtimeOverhead = useObservedArtifactSize ? 0.35 : 0.5;
+        const usedMoeTotal = parameterProfile.isMoE && weightParamsB === parameterProfile.totalParamsB;
         const memorySource = useObservedArtifactSize
             ? 'observed_artifact_size'
-            : (preferSparseInferenceParams ? 'moe_sparse_inference_params' : 'estimated_from_params');
+            : (usedMoeTotal ? 'moe_total_params' : 'estimated_from_params');
 
         return {
             parameterProfile,

--- a/tests/deterministic-model-pool-check.js
+++ b/tests/deterministic-model-pool-check.js
@@ -744,7 +744,7 @@ async function runMoECompleteMetadataUsesActiveParams() {
     assert.ok(moeBreakdown.requiredGB < denseRequired, 'MoE active-param estimate should be smaller than dense equivalent');
 }
 
-async function runMoEActivePathOverridesObservedArtifactSize() {
+async function runMoEObservedArtifactSizeWinsOverActiveParams() {
     const selector = new DeterministicModelSelector();
     const denseEquivalent = {
         paramsB: 46,
@@ -765,18 +765,22 @@ async function runMoEActivePathOverridesObservedArtifactSize() {
     const denseBreakdown = selector.estimateMemoryBreakdown(denseEquivalent, 'Q4_K_M', 8192);
     const moeBreakdown = selector.estimateMemoryBreakdown(moeModel, 'Q4_K_M', 8192);
 
+    // A real measured on-disk size must win for weight memory: all experts are
+    // resident under Ollama / Metal / vLLM, so the MoE cannot shrink to its active
+    // footprint and falsely "fit" hardware it can't run on.
     assert.strictEqual(
         moeBreakdown.memorySource,
-        'moe_sparse_inference_params',
-        'Complete MoE metadata should prioritize sparse inference params over artifact-size fallback'
+        'observed_artifact_size',
+        'Observed artifact size must win over the MoE sparse-inference assumption'
+    );
+    assert.strictEqual(
+        moeBreakdown.modelMemGB,
+        denseBreakdown.modelMemGB,
+        'MoE weight memory equals the observed artifact size, same as the dense equivalent'
     );
     assert.ok(
-        moeBreakdown.modelMemGB < denseBreakdown.modelMemGB,
-        'MoE model memory should be lower than dense equivalent even when artifact size metadata exists'
-    );
-    assert.ok(
-        moeBreakdown.requiredGB < denseBreakdown.requiredGB,
-        'MoE required memory should remain below dense equivalent when active metadata is available'
+        moeBreakdown.requiredGB <= denseBreakdown.requiredGB + 1e-9,
+        'MoE total may only be lower via a smaller KV cache, never via shrunken weights'
     );
 }
 
@@ -937,7 +941,7 @@ async function runAll() {
     await runDenseMemoryPathUsesDenseParams();
     await runConvertedVariantCarriesExplicitMoEMetadataSchemaFields();
     await runMoECompleteMetadataUsesActiveParams();
-    await runMoEActivePathOverridesObservedArtifactSize();
+    await runMoEObservedArtifactSizeWinsOverActiveParams();
     await runMoEPartialMetadataFallsBackDeterministically();
     await runMoERuntimeProfilesChangeSpeedEstimate();
     await runRuntimePropagationInCategoryRecommendations();

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -21,6 +21,7 @@ import {
   mapHardwareJson,
   detectFrameworkMarker,
   FRAMEWORK_MARKERS,
+  ALLOWED_CLI_COMMANDS,
 } from "../bin/mcp-server.mjs";
 
 function fail(msg) {
@@ -131,6 +132,12 @@ try {
     "detectFrameworkMarker on an unknown name must be null"
   );
   assert.strictEqual(FRAMEWORK_MARKERS[".github"], "GitHub Actions", "FRAMEWORK_MARKERS must contain .github");
+
+  // (e) The cli_exec allowlist must expose the v3.7 registry commands so they are
+  // reachable from MCP clients.
+  for (const cmd of ["registry-sync", "registry-search", "registry-recommend"]) {
+    assert.ok(ALLOWED_CLI_COMMANDS.has(cmd), `ALLOWED_CLI_COMMANDS must include ${cmd}`);
+  }
 
   console.log("mcp-server.test.mjs: OK");
   process.exit(0);

--- a/tests/model-registry-param-parsing.test.js
+++ b/tests/model-registry-param-parsing.test.js
@@ -144,6 +144,24 @@ async function testRuntimeLikeEscape() {
     }
 }
 
+function testShardedFileSizeNotUsedAsModelSize() {
+    // A single shard's size must NOT stand in for the whole model: a 56B model
+    // whose shard is 4.66GB must be sized from params, not "fit" as 4.66GB.
+    const model = artifactToSelectorModel({
+        source_id: 'huggingface',
+        repo_id: 'org/Big-56B',
+        canonical_model_id: 'org/Big-56B',
+        artifact_name: 'model-00001-of-00012.safetensors',
+        filename: 'model-00001-of-00012.safetensors',
+        parameter_count_b: 56,
+        size_gb: 4.66
+    });
+    assert.ok(model, 'sharded artifact still maps');
+    assert.strictEqual(model.paramsB, 56, 'keeps the full param count');
+    assert.strictEqual(model.sizeGB, undefined, 'per-shard size must not become the model size');
+    assert.deepStrictEqual(model.sizeByQuant, {}, 'no observed size from a shard');
+}
+
 async function run() {
     testMoEParamParsing();
     testContextTokenNotMisreadAsParams();
@@ -151,6 +169,7 @@ async function run() {
     testRecommenderActiveParamTotalSizing();
     testHugeMoEDoesNotFitSmallHardware();
     testGpt4AllTrailingSlashName();
+    testShardedFileSizeNotUsedAsModelSize();
     await testRuntimeLikeEscape();
     console.log('model-registry-param-parsing.test.js: OK');
 }

--- a/tests/registry-diversity.test.js
+++ b/tests/registry-diversity.test.js
@@ -69,11 +69,39 @@ function testDiversityDoesNotPromoteFarBehindSource() {
     assert.deepStrictEqual(out.map((c) => c.meta.name), ['a', 'b'], 'far-behind source not forced in');
 }
 
+function testDiversityKeepsGenuineTopUnderRareSourceFlood() {
+    // 3 strong ollama models + 9 distinct rare sources all within the margin.
+    // Diversity must NOT drop both runners-up to seed obscure sources.
+    const distinct = [
+        cand('o0', 'ollama', 100),
+        cand('o1', 'ollama', 99),
+        cand('o2', 'ollama', 98)
+    ];
+    for (let i = 0; i < 9; i++) distinct.push(cand('r' + i, 'src' + i, 86));
+    const out = applySourceDiversity(distinct, 3);
+    const names = out.map((c) => c.meta.name);
+    assert.strictEqual(out.length, 3, 'returns exactly the limit');
+    assert.ok(names.includes('o0') && names.includes('o1'), 'genuine top-2 ollama picks are preserved');
+    const rareCount = out.filter((c) => c.meta.source.startsWith('src')).length;
+    assert.ok(rareCount <= 1, `at most one diversity seed, got ${rareCount}`);
+}
+
+function testCollapseKeepsDistinctUnknownParamModels() {
+    // Two genuinely different models with no params must NOT collapse to one.
+    const out = collapseToDistinctModels([
+        { score: 90, meta: { name: 'some-embed', paramsB: null, source: 'ollama', model_identifier: 'some-embed:a' } },
+        { score: 85, meta: { name: 'some-embed', paramsB: 0, source: 'huggingface', model_identifier: 'org/some-embed' } }
+    ]);
+    assert.strictEqual(out.length, 2, 'distinct unknown-param models stay distinct (no "na" collision)');
+}
+
 function run() {
     testCollapseVariants();
     testDiversityKeyIgnoresTagAndQuant();
     testSourceDiversitySurfacesCloseSource();
     testDiversityDoesNotPromoteFarBehindSource();
+    testDiversityKeepsGenuineTopUnderRareSourceFlood();
+    testCollapseKeepsDistinctUnknownParamModels();
     console.log('registry-diversity.test.js: OK');
 }
 

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -18,6 +18,7 @@ const TESTS = [
     { name: 'Termux platform support', file: 'termux-platform-support.test.js', category: 'Hardware' },
     { name: 'Token speed estimation', file: 'token-speed-estimation.test.js', category: 'Performance' },
     { name: 'Deterministic model pool', file: 'deterministic-model-pool-check.js', category: 'Recommendations' },
+    { name: 'Selector memory sizing', file: 'selector-memory-sizing.test.js', category: 'Recommendations' },
     { name: 'Multi-objective selector regression', file: 'multi-objective-selector-regression.test.js', category: 'Recommendations' },
     { name: 'Scoring engine unification', file: 'scoring-unification.test.js', category: 'Recommendations' },
     { name: 'Fine-tuning support helper', file: 'fine-tuning-support.test.js', category: 'Recommendations' },

--- a/tests/selector-memory-sizing.test.js
+++ b/tests/selector-memory-sizing.test.js
@@ -1,0 +1,102 @@
+/**
+ * Deterministic selector memory/sizing regression tests
+ * =====================================================
+ * Covers bug fixes that prevented FALSE "fits":
+ *   - MoE weight memory uses the TOTAL params (and a real observed artifact size
+ *     always wins), so a big MoE can't shrink to its active footprint.
+ *   - Multi-GPU VRAM is not double-counted (a 2x24=48GB box stays 48GB).
+ *   - filterByCategory tolerates malformed pool rows instead of throwing.
+ *   - A size-unknown Ollama variant (`:latest`) can't poison a sibling's size map
+ *     by inheriting model_sizes[0].
+ */
+
+const assert = require('assert');
+const DeterministicModelSelector = require('../src/models/deterministic-selector');
+
+function testMoEObservedSizeWins() {
+    const s = new DeterministicModelSelector();
+    // 236B-total / 21B-active MoE with a REAL observed Q4 size of 133GB.
+    const moe = {
+        paramsB: 236, quant: 'Q4_K_M', sizeByQuant: { Q4_K_M: 133 },
+        isMoE: true, totalParamsB: 236, activeParamsB: 21
+    };
+    const b = s.estimateMemoryBreakdown(moe, 'Q4_K_M', 8192);
+    assert.strictEqual(b.memorySource, 'observed_artifact_size', 'observed size must win');
+    assert.ok(b.requiredGB > 130, `236B MoE must require >130GB, got ${b.requiredGB.toFixed(1)}`);
+}
+
+function testMoEModeledUsesTotalParams() {
+    const s = new DeterministicModelSelector();
+    // No observed size -> must model weights from TOTAL params, not active.
+    const moe = { paramsB: 236, quant: 'Q4_K_M', isMoE: true, totalParamsB: 236, activeParamsB: 21 };
+    const b = s.estimateMemoryBreakdown(moe, 'Q4_K_M', 8192);
+    assert.ok(b.requiredGB > 100, `modeled 236B MoE must require >100GB, got ${b.requiredGB.toFixed(1)}`);
+    assert.notStrictEqual(b.memorySource, 'moe_sparse_inference_params', 'sparse-inference sizing must be gone');
+}
+
+function testMultiGpuVramNotDoubled() {
+    const s = new DeterministicModelSelector();
+    // 2x24=48GB reported as a single total `vramGB:48`; must NOT become 96.
+    const norm = s.normalizeHardwareProfile({
+        gpu: { type: 'nvidia', vramGB: 48, gpuCount: 2, isMultiGPU: true }, memory: { totalGB: 64 }
+    });
+    assert.strictEqual(norm.gpu.vramGB, 48, 'a total VRAM figure must not be multiplied by gpuCount');
+
+    // Explicit per-GPU memory IS scaled up.
+    const perGpu = s.normalizeHardwareProfile({
+        gpu: { type: 'nvidia', vramPerGPU: 24, gpuCount: 2, isMultiGPU: true }, memory: { totalGB: 64 }
+    });
+    assert.strictEqual(perGpu.gpu.vramGB, 48, 'per-GPU memory should scale to the box total');
+}
+
+function testFilterByCategoryToleratesMalformedRows() {
+    const s = new DeterministicModelSelector();
+    // Missing tags/modalities/name must not throw.
+    assert.doesNotThrow(() => s.filterByCategory([{ model_identifier: 'x' }], 'coding'));
+    assert.doesNotThrow(() => s.filterByCategory([{ model_identifier: 'x' }], 'multimodal'));
+    const general = s.filterByCategory([{ model_identifier: 'x' }], 'general');
+    assert.strictEqual(general.length, 1, 'a malformed row still passes the general category');
+}
+
+function testLatestVariantDoesNotPoisonSiblingSize() {
+    const s = new DeterministicModelSelector();
+    const model = {
+        model_identifier: 'qwen3', model_name: 'qwen3',
+        model_sizes: ['30b', '235b'],
+        variants: [
+            { tag: 'qwen3:30b', quantization: 'Q4_K_M', real_size_gb: 19, size: '19GB' },
+            { tag: 'qwen3:latest', quantization: 'Q4_K_M', real_size_gb: 5.2, size: 'unknown' }
+        ]
+    };
+    const conv = s.convertOllamaModelToDeterministicModels(model);
+    const v30 = conv.find((c) => c.model_identifier === 'qwen3:30b');
+    const vlatest = conv.find((c) => c.model_identifier === 'qwen3:latest');
+
+    assert.strictEqual(v30.paramsB, 30, 'qwen3:30b keeps its 30B param count');
+    assert.strictEqual(v30.sizeByQuant.Q4_K_M, 19, 'qwen3:30b Q4 size must stay 19GB (not poisoned to 5.2)');
+    assert.ok(vlatest.paramsB < 15, `qwen3:latest must be sized small (~9B), not 30B; got ${vlatest.paramsB}`);
+
+    const mem = s.estimateMemoryBreakdown(v30, 'Q4_K_M', 8192);
+    assert.ok(mem.requiredGB > 18, `qwen3:30b must require >18GB (not ~6); got ${mem.requiredGB.toFixed(1)}`);
+}
+
+function run() {
+    testMoEObservedSizeWins();
+    testMoEModeledUsesTotalParams();
+    testMultiGpuVramNotDoubled();
+    testFilterByCategoryToleratesMalformedRows();
+    testLatestVariantDoesNotPoisonSiblingSize();
+    console.log('selector-memory-sizing.test.js: OK');
+}
+
+if (require.main === module) {
+    try {
+        run();
+    } catch (error) {
+        console.error('selector-memory-sizing.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+module.exports = { run };


### PR DESCRIPTION
## Why
A multi-area bug-hunt (3 parallel reviewers) found several **verified** causes of false "fits" and dropped picks. This PR fixes the highest-value ones, each with a test.

## Fixes (all reproduced before fixing)
- **MoE memory sized by active params (false fits).** `estimateMemoryBreakdown` now sizes MoE weights by the **total** param count, and a real observed artifact size **always** wins. Removed the "sparse inference" override that made a 236B MoE look ~14GB and "fit" a 16GB box. This closes the **Ollama-catalog** path the 3.7.0 registry fix didn't cover.
- **`:latest` variant poisoning sibling sizes (fires on real cached data).** `resolveVariantParamsB` now disambiguates `model_sizes` using the variant's **own** artifact size, so `qwen3:latest` is sized ~9B (not 30B from `model_sizes[0]`) and no longer poisons the real `qwen3:30b` size map — `qwen3:30b` correctly needs ~21GB and does **not** fit 16GB.
- **Multi-GPU VRAM double-counted.** A bare total `vramGB` is treated as the box total (a 2×24=48GB box stays 48GB, not 96GB); only explicit per-GPU `vramPerGPU` is scaled.
- **`filterByCategory` crash.** Guards `tags`/`modalities`/`name` so one malformed pool row can't throw and silently empty an entire category.
- **Diversity dropped genuine top picks.** `applySourceDiversity` reserves ~60% of slots for best-by-score, so it can't drop several real runners-up to seed obscure sources.
- **Sharded HF size used as model size.** A per-shard file size (e.g. 4.66GB of a 56B model) is no longer treated as the whole-model size; memory estimates from params instead.
- **Unknown-param dedup collision.** `modelDiversityKey` no longer collapses distinct unknown-param models of the same name into one.
- **MCP gap.** `registry-sync`/`registry-search`/`registry-recommend` added to the `cli_exec` allowlist (exported + tested).

## Validation
- Full suite **46/46**. New `tests/selector-memory-sizing.test.js`; added cases to `registry-diversity`, `model-registry-param-parsing`, `mcp-server`; and corrected a `deterministic-model-pool-check` assertion that had pinned the old (buggy) sparse-inference behavior.
- Bumps to **3.7.2**.

## Deferred (noted, follow-up)
Lower-priority items found but not in this PR: CLI `--runtime/--source/--format` enum validation (invalid values currently render as "no results"); registry ingestor data-quality (LoRA adapters ingested as models, shard row inflation, GPT4All comma-size, bf16-as-quant) which need a seed regen; dead `idx_model_artifacts_runtime` index + dead `better-sqlite3` branch + duplicated `inferFamily`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)