### PR TITLE
fix(cli): validate registry enum options + no internal-catalog fallback

### DIFF
--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -410,6 +410,30 @@ function parsePositiveNumberOption(value, fallback = null) {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
 }
 
+// Allowed enum values for the registry commands. Invalid values must be rejected
+// with a clear error instead of silently returning "no results" or falling back
+// to the built-in catalog.
+const REGISTRY_SOURCES = ['ollama', 'huggingface', 'gpt4all'];
+const REGISTRY_FORMATS = ['gguf', 'safetensors', 'mlx', 'ollama', 'pytorch', 'pytorch_bin', 'ggml'];
+const REGISTRY_RUNTIMES = ['auto', 'all', '*', 'ollama', 'llama.cpp', 'transformers', 'vllm', 'mlx'];
+const REGISTRY_OPTIMIZE = ['balanced', 'speed', 'quality', 'context', 'coding'];
+
+function assertRegistryEnum(label, value, allowed) {
+    if (value === undefined || value === null || value === '') return;
+    if (!allowed.includes(String(value).toLowerCase())) {
+        const shown = allowed.filter((v) => !['all', '*'].includes(v)).join(', ');
+        throw new Error(`Invalid --${label} "${value}". Allowed: ${shown}`);
+    }
+}
+
+// Throws on the first invalid registry enum option. Returns nothing on success.
+function validateRegistryFilters(options = {}) {
+    assertRegistryEnum('source', options.source, REGISTRY_SOURCES);
+    assertRegistryEnum('format', options.format, REGISTRY_FORMATS);
+    assertRegistryEnum('runtime', options.runtime, REGISTRY_RUNTIMES);
+    assertRegistryEnum('optimize', options.optimize, REGISTRY_OPTIMIZE);
+}
+
 function truncateMiddle(value, maxLength = 48) {
     const text = String(value || '');
     if (text.length <= maxLength) return text;
@@ -4886,6 +4910,17 @@ program
     .option('-l, --limit <n>', 'Maximum number of results', '20')
     .option('-j, --json', 'Output as JSON')
     .action(async (query = '', options) => {
+        try {
+            validateRegistryFilters(options);
+        } catch (validationError) {
+            if (options.json) {
+                console.log(JSON.stringify({ error: validationError.message }, null, 2));
+            } else {
+                console.error(chalk.red(`✗ ${validationError.message}`));
+            }
+            process.exitCode = 1;
+            return;
+        }
         if (!options.json) showAsciiArt('registry-search');
 
         const ModelDatabase = require('../src/data/model-database');
@@ -4993,6 +5028,17 @@ program
     .option('-l, --limit <n>', 'Maximum number of recommendations', '10')
     .option('-j, --json', 'Output as JSON')
     .action(async (query = '', options) => {
+        try {
+            validateRegistryFilters(options);
+        } catch (validationError) {
+            if (options.json) {
+                console.log(JSON.stringify({ error: validationError.message }, null, 2));
+            } else {
+                console.error(chalk.red(`✗ ${validationError.message}`));
+            }
+            process.exitCode = 1;
+            return;
+        }
         if (!options.json) showAsciiArt('registry-recommend');
 
         const UnifiedDetector = require('../src/hardware/unified-detector');

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+3.7.3 — Registry CLI Validation (2026-06-20)
+--------------------------------------------
+
+- `registry-search` and `registry-recommend` now reject invalid `--source`,
+  `--format`, `--runtime`, and `--optimize` values with a clear error (exit 1 /
+  JSON `{error}`) instead of silently returning "no results" or echoing a bogus
+  runtime.
+- When no registry artifacts match the filters, `registry-recommend` returns an
+  empty result rather than silently substituting the deterministic selector's
+  built-in catalog (which previously surfaced non-registry rows mislabeled as a
+  "Multi-source registry" result with `total_artifacts: 0`).
+- New `tests/registry-cli-validation.test.js` (spawn-based enum rejection +
+  empty-pool guard). Full suite 47/47.
+
 3.7.2 — Memory-sizing & Recommendation Hardening (2026-06-20)
 ------------------------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.7.2",
+      "version": "3.7.3",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.7.2",
+  "version": "3.7.3",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -443,6 +443,26 @@ class RegistryRecommender {
 
         const selectorHardware = normalizeHardwareForSelector(options.hardware || {});
         const normalizedRuntime = runtimeFilter || 'auto';
+
+        // No registry artifacts matched the filters: return an empty result rather
+        // than letting the deterministic selector silently substitute its built-in
+        // catalog (which would mislabel non-registry models as "registry" rows).
+        if (modelPool.length === 0) {
+            return {
+                category,
+                runtime: normalizedRuntime,
+                rows,
+                modelPool,
+                result: {
+                    category,
+                    optimizeFor: this.selector.normalizeOptimizationObjective(options.optimizeFor || 'balanced'),
+                    runtime: normalizedRuntime,
+                    candidates: [],
+                    total_evaluated: 0,
+                    timestamp: new Date().toISOString()
+                }
+            };
+        }
         // Rank a wider window than requested so we can collapse model variants and
         // apply source diversity before trimming to the caller's limit.
         const rankWindow = Math.max(limit * 8, 200);

--- a/tests/registry-cli-validation.test.js
+++ b/tests/registry-cli-validation.test.js
@@ -1,0 +1,82 @@
+/**
+ * Registry CLI validation + empty-pool guard test
+ * ===============================================
+ *   - registry-search / registry-recommend reject invalid enum options with a
+ *     clear error (exit 1 / JSON {error}) instead of silently returning "no
+ *     results" or falling back to the built-in catalog.
+ *   - When no registry artifacts match the filters, selectCategory returns an
+ *     empty result rather than letting the deterministic selector substitute its
+ *     internal catalog (which would mislabel non-registry rows as "registry").
+ */
+
+const assert = require('assert');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const { RegistryRecommender } = require('../src/data/registry-recommender');
+
+const CLI = path.join(__dirname, '..', 'bin', 'enhanced_cli.js');
+
+function runCli(args) {
+    const res = spawnSync(process.execPath, [CLI, ...args], { encoding: 'utf8' });
+    return { status: res.status, stdout: res.stdout || '', stderr: res.stderr || '' };
+}
+
+function testInvalidSourceRejected() {
+    const { status, stdout } = runCli(['registry-search', 'llama', '--source', 'bogus', '--json']);
+    assert.strictEqual(status, 1, 'invalid --source must exit non-zero');
+    const payload = JSON.parse(stdout);
+    assert.ok(/Invalid --source/.test(payload.error), 'must report an invalid-source error');
+}
+
+function testInvalidRuntimeRejected() {
+    const { status, stdout } = runCli(['registry-recommend', '--runtime', 'garbage', '--json']);
+    assert.strictEqual(status, 1, 'invalid --runtime must exit non-zero');
+    const payload = JSON.parse(stdout);
+    assert.ok(/Invalid --runtime/.test(payload.error), 'must report an invalid-runtime error');
+}
+
+function testValidSourceAccepted() {
+    const { status, stdout } = runCli(['registry-search', 'bert', '--source', 'huggingface', '--json', '--limit', '1']);
+    assert.strictEqual(status, 0, 'valid --source must exit 0');
+    const payload = JSON.parse(stdout);
+    assert.ok(!('error' in payload), 'valid filters must not produce an error');
+}
+
+async function testEmptyPoolDoesNotFallBackToInternalCatalog() {
+    // Fake DB that matches zero artifacts; fake selector whose selectModels MUST
+    // NOT be called (calling it would load the built-in catalog).
+    const fakeDatabase = {
+        async initialize() {},
+        searchModelArtifacts() { return []; },
+        getRegistryStats() { return { sources: 0, repos: 0, artifacts: 0 }; },
+        close() {}
+    };
+    const fakeSelector = {
+        normalizeOptimizationObjective(v) { return v || 'balanced'; },
+        async selectModels() { throw new Error('selectModels must not run when the registry pool is empty'); }
+    };
+    const rec = new RegistryRecommender({ database: fakeDatabase, selector: fakeSelector });
+    await rec.initialize();
+    const out = await rec.recommend({ category: 'coding', runtime: 'mlx' });
+    assert.strictEqual(out.total_artifacts, 0, 'no artifacts matched');
+    assert.deepStrictEqual(out.recommendations, [], 'empty pool yields no recommendations (not internal-catalog rows)');
+}
+
+async function run() {
+    testInvalidSourceRejected();
+    testInvalidRuntimeRejected();
+    testValidSourceAccepted();
+    await testEmptyPoolDoesNotFallBackToInternalCatalog();
+    console.log('registry-cli-validation.test.js: OK');
+}
+
+if (require.main === module) {
+    run().catch((error) => {
+        console.error('registry-cli-validation.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = { run };

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -25,6 +25,7 @@ const TESTS = [
     { name: 'Model registry ingestors', file: 'model-registry-ingestors.test.js', category: 'Recommendations' },
     { name: 'Model registry param parsing', file: 'model-registry-param-parsing.test.js', category: 'Recommendations' },
     { name: 'Registry recommendation diversity', file: 'registry-diversity.test.js', category: 'Recommendations' },
+    { name: 'Registry CLI validation', file: 'registry-cli-validation.test.js', category: 'Recommendations' },
     { name: 'Model registry recommender', file: 'model-registry-recommender.test.js', category: 'Recommendations' },
     { name: 'Model registry main flow', file: 'model-registry-main-flow.test.js', category: 'Recommendations' },
     { name: 'Packaged model registry seed', file: 'model-registry-seed.test.js', category: 'Recommendations' },


### PR DESCRIPTION
## Why
Follow-up to the bug-hunt. Two trust issues with the registry CLI:
- Invalid `--source/--format/--runtime/--optimize` silently produced "no results" (or echoed a bogus runtime), looking like an empty registry.
- An over-restrictive filter that emptied the registry pool let `registry-recommend` silently fall back to the deterministic selector's **built-in catalog**, returning non-registry rows mislabeled as a "Multi-source registry" result with `total_artifacts: 0`.

## What changed
- Added a registry enum validator; `registry-search`/`registry-recommend` now reject invalid values with a clear error (exit 1, JSON `{error}`) listing the allowed values.
- `selectCategory` returns an empty result when no artifacts match, so a registry command never substitutes the internal catalog.

## Validation
- New `tests/registry-cli-validation.test.js`: spawn-based enum rejection (`--source bogus`, `--runtime garbage`) + a unit test proving the empty pool does **not** call `selectModels` (the internal-catalog path).
- Full suite **47/47**. Bumps to **3.7.3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)