### PR TITLE
fix(registry): ingestor data quality + seed regen

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+3.7.4 — Registry Ingestor Data Quality (2026-06-20)
+---------------------------------------------------
+
+Cleaner packaged registry (seed DB regenerated):
+
+- LoRA/PEFT adapters (`adapter_model.*`) and optimizer/training-state files are no
+  longer ingested as standalone models (they previously appeared as tiny "models"
+  inheriting the repo's full param count). Mistral-style `consolidated.*.pth`
+  weights are now kept.
+- `F16`/`FP16`/`BF16` are treated as precisions, not quantizations — a
+  full-precision Hugging Face model is no longer mislabeled as "quantized".
+- GPT4All: comma-formatted file sizes now parse (no more NULL size), and an entry
+  whose download points at a Hugging Face repo adopts that repo id as its
+  canonical model id so it lines up with the HF/Ollama copies for dedup.
+- Dropped the dead `idx_model_artifacts_runtime` index (a JSON column only queried
+  with LIKE); the schema now drops it from existing DBs on open.
+- Regenerated `src/data/seed/models.db`: 3 sources, 3,259 repos, 32,779 artifacts.
+
+New `tests/registry-ingestor-quality.test.js`. Full suite 48/48.
+
 3.7.3 — Registry CLI Validation (2026-06-20)
 --------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.7.3",
+      "version": "3.7.4",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.7.3",
+  "version": "3.7.4",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",

--- a/src/data/model-database.js
+++ b/src/data/model-database.js
@@ -227,9 +227,11 @@ class ModelDatabase {
             CREATE INDEX IF NOT EXISTS idx_model_artifacts_source ON model_artifacts(source_id);
             CREATE INDEX IF NOT EXISTS idx_model_artifacts_format ON model_artifacts(format);
             CREATE INDEX IF NOT EXISTS idx_model_artifacts_quant ON model_artifacts(quantization);
-            CREATE INDEX IF NOT EXISTS idx_model_artifacts_runtime ON model_artifacts(runtime_support);
             CREATE INDEX IF NOT EXISTS idx_model_artifacts_size ON model_artifacts(size_gb);
             CREATE INDEX IF NOT EXISTS idx_model_artifacts_downloads ON model_artifacts(downloads DESC);
+            -- Drop a dead index from older DBs: runtime_support is a JSON blob only
+            -- queried with LIKE, so a B-tree index on it is never used.
+            DROP INDEX IF EXISTS idx_model_artifacts_runtime;
         `;
 
         if (this.useBetterSqlite) {

--- a/src/data/registry-ingestors.js
+++ b/src/data/registry-ingestors.js
@@ -146,8 +146,10 @@ function parseActiveParamsB(...values) {
 
 function inferQuantization(...values) {
     const text = values.map((value) => String(value || '')).join(' ');
-    const ggufQuant = text.match(/\b(IQ\d(?:_[A-Z0-9]+)?|Q\d(?:_[A-Z0-9]+){0,2}|F16|FP16|BF16|Q8_0)\b/i);
-    if (ggufQuant) return ggufQuant[1].toUpperCase().replace(/^F16$/, 'FP16');
+    // Note: F16/FP16/BF16 are PRECISIONS, not quantizations — they're handled by
+    // inferPrecision so a full-precision model isn't mislabeled as "quantized".
+    const ggufQuant = text.match(/\b(IQ\d(?:_[A-Z0-9]+)?|Q\d(?:_[A-Z0-9]+){0,2}|Q8_0)\b/i);
+    if (ggufQuant) return ggufQuant[1].toUpperCase();
 
     const bitQuant = text.match(/\b([234568])\s*[-_ ]?bit\b/i);
     if (bitQuant) return `${bitQuant[1]}bit`;
@@ -271,9 +273,16 @@ function getSiblingSizeBytes(sibling = {}) {
 function isModelArtifactFile(filename) {
     const lower = String(filename || '').toLowerCase();
     if (!lower) return false;
+    // Exclude non-model weight files that would otherwise be ingested as standalone
+    // "models": LoRA/PEFT adapters (a few MB but inherit the repo's param count) and
+    // optimizer/training state.
+    if (/(^|[/_-])adapter[_-]?(model|config)/.test(lower)) return false;
+    if (/(^|[/_-])(lora|optimizer|scheduler|rng_state|trainer_state|training_args)/.test(lower)) return false;
     if (lower.endsWith('.gguf')) return true;
     if (lower.endsWith('.safetensors')) return true;
-    if (/pytorch_model.*\.bin$/.test(lower)) return true;
+    if (/pytorch_model.*\.(bin)$/.test(lower)) return true;
+    // Mistral-style consolidated weights (consolidated.00.pth) were being dropped.
+    if (/(^|[/])consolidated.*\.(pt|pth|bin)$/.test(lower)) return true;
     if (/model.*\.(bin|pt|pth)$/.test(lower)) return true;
     if (/ggml.*\.bin$/.test(lower)) return true;
     return false;
@@ -398,11 +407,15 @@ function normalizeGpt4AllEntry(entry) {
 
     const repoMatch = url.match(/huggingface\.co\/([^/]+\/[^/]+)\/resolve\/([^/]+)\/(.+)$/);
     const repoId = repoMatch ? repoMatch[1] : `gpt4all/${name}`;
+    // When the download points at a Hugging Face repo, use that repo id as the
+    // canonical model id so the same model lines up across sources for dedup.
+    const canonicalModelId = repoMatch ? repoMatch[1] : name;
     const filename = repoMatch ? decodeURIComponent(repoMatch[3]) : (filenameCandidate || url.split('/').filter(Boolean).pop());
     const repoKey = makeScopedId('gpt4all', repoId);
     const tags = ['gpt4all', entry.type, entry.quant].filter(Boolean);
     const paramsB = parseParamsB(entry.parameters, name, filename);
-    const sizeBytes = Number(entry.filesize || entry.fileSize || entry.size || 0) || null;
+    // Sizes can arrive as comma-formatted strings ("8,000,000,000"); strip non-digits.
+    const sizeBytes = Number(String(entry.filesize ?? entry.fileSize ?? entry.size ?? 0).replace(/[^0-9.]/g, '')) || null;
     const format = inferFormat(filename, tags);
 
     return {
@@ -412,7 +425,7 @@ function normalizeGpt4AllEntry(entry) {
             source_id: 'gpt4all',
             repo_id: repoId,
             namespace: repoId.includes('/') ? repoId.split('/')[0] : 'gpt4all',
-            canonical_model_id: name,
+            canonical_model_id: canonicalModelId,
             display_name: name,
             url: repoMatch ? `https://huggingface.co/${repoId}` : url,
             license: entry.license || 'unknown',
@@ -434,7 +447,7 @@ function normalizeGpt4AllEntry(entry) {
             source_id: 'gpt4all',
             repo_key: repoKey,
             repo_id: repoId,
-            canonical_model_id: name,
+            canonical_model_id: canonicalModelId,
             artifact_name: filename || name,
             filename: filename || '',
             format,
@@ -746,6 +759,7 @@ module.exports = {
     inferFormat,
     inferQuantization,
     inferRuntimeSupport,
+    isModelArtifactFile,
     parseParamsB,
     buildHuggingFaceDownloadUrl
 };

--- a/tests/registry-ingestor-quality.test.js
+++ b/tests/registry-ingestor-quality.test.js
@@ -1,0 +1,81 @@
+/**
+ * Registry ingestor data-quality test
+ * ===================================
+ *   - LoRA/PEFT adapters and optimizer/training files are NOT ingested as models;
+ *     Mistral-style consolidated weights ARE.
+ *   - F16/FP16/BF16 are precisions, not quantizations.
+ *   - GPT4All comma-formatted sizes parse, and an HF-backed download adopts the HF
+ *     repo id as the canonical model id (cross-source alignment).
+ */
+
+const assert = require('assert');
+const {
+    isModelArtifactFile,
+    inferQuantization,
+    normalizeGpt4AllEntry
+} = require('../src/data/registry-ingestors');
+
+function testArtifactFileFiltering() {
+    // Real model weights -> included
+    assert.strictEqual(isModelArtifactFile('model-00001-of-00005.safetensors'), true, 'shard is a model file');
+    assert.strictEqual(isModelArtifactFile('model.gguf'), true);
+    assert.strictEqual(isModelArtifactFile('pytorch_model.bin'), true);
+    assert.strictEqual(isModelArtifactFile('consolidated.00.pth'), true, 'consolidated weights must be kept');
+    // Non-model files -> excluded
+    assert.strictEqual(isModelArtifactFile('adapter_model.safetensors'), false, 'LoRA adapter is NOT a model');
+    assert.strictEqual(isModelArtifactFile('adapter_config.json'), false);
+    assert.strictEqual(isModelArtifactFile('optimizer.pt'), false, 'optimizer state is not a model');
+    assert.strictEqual(isModelArtifactFile('training_args.bin'), false);
+    assert.strictEqual(isModelArtifactFile('tokenizer.json'), false);
+}
+
+function testPrecisionNotTreatedAsQuantization() {
+    assert.strictEqual(inferQuantization('model-bf16.safetensors'), '', 'bf16 is a precision, not a quant');
+    assert.strictEqual(inferQuantization('model-fp16.safetensors'), '', 'fp16 is a precision, not a quant');
+    assert.strictEqual(inferQuantization('model-Q4_K_M.gguf'), 'Q4_K_M', 'real quant still detected');
+    assert.strictEqual(inferQuantization('model-Q8_0.gguf'), 'Q8_0');
+}
+
+function testGpt4AllCommaSizeParses() {
+    const entry = normalizeGpt4AllEntry({
+        name: 'orca-mini-3b.gguf',
+        url: 'https://gpt4all.io/models/gguf/orca-mini-3b.gguf',
+        filesize: '8,000,000,000'
+    });
+    assert.ok(entry, 'entry maps');
+    const size = entry.artifacts[0].size_gb;
+    assert.ok(size && size > 7 && size < 9, `comma size must parse to ~8GB, got ${size}`);
+}
+
+function testGpt4AllCanonicalFromHfRepo() {
+    const entry = normalizeGpt4AllEntry({
+        name: 'Mistral Instruct',
+        url: 'https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_0.gguf'
+    });
+    assert.ok(entry, 'entry maps');
+    assert.strictEqual(
+        entry.artifacts[0].canonical_model_id,
+        'TheBloke/Mistral-7B-Instruct-v0.1-GGUF',
+        'HF-backed GPT4All entry adopts the HF repo id as canonical model id'
+    );
+}
+
+function run() {
+    testArtifactFileFiltering();
+    testPrecisionNotTreatedAsQuantization();
+    testGpt4AllCommaSizeParses();
+    testGpt4AllCanonicalFromHfRepo();
+    console.log('registry-ingestor-quality.test.js: OK');
+}
+
+if (require.main === module) {
+    try {
+        run();
+    } catch (error) {
+        console.error('registry-ingestor-quality.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+module.exports = { run };

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -23,6 +23,7 @@ const TESTS = [
     { name: 'Scoring engine unification', file: 'scoring-unification.test.js', category: 'Recommendations' },
     { name: 'Fine-tuning support helper', file: 'fine-tuning-support.test.js', category: 'Recommendations' },
     { name: 'Model registry ingestors', file: 'model-registry-ingestors.test.js', category: 'Recommendations' },
+    { name: 'Registry ingestor quality', file: 'registry-ingestor-quality.test.js', category: 'Recommendations' },
     { name: 'Model registry param parsing', file: 'model-registry-param-parsing.test.js', category: 'Recommendations' },
     { name: 'Registry recommendation diversity', file: 'registry-diversity.test.js', category: 'Recommendations' },
     { name: 'Registry CLI validation', file: 'registry-cli-validation.test.js', category: 'Recommendations' },


### PR DESCRIPTION
## Why
Second half of the bug-hunt follow-up: registry data-quality issues that polluted the packaged seed.

## What changed (seed DB regenerated)
- **LoRA/PEFT adapters no longer ingested as models.** `adapter_model.*` and optimizer/training-state files were ingested as tiny "models" inheriting the repo's full param count. Now excluded; Mistral-style `consolidated.*.pth` weights are now kept.
- **F16/FP16/BF16 treated as precision, not quantization** — a full-precision HF model is no longer mislabeled as "quantized" (and `--quant BF16` no longer matches unquantized models).
- **GPT4All:** comma-formatted file sizes now parse (no more NULL size); an entry whose download points at an HF repo adopts that repo id as `canonical_model_id` so it lines up across sources for dedup.
- **Dropped the dead `idx_model_artifacts_runtime` index** (JSON column only queried with LIKE); the schema drops it from existing DBs on open.
- **Regenerated `src/data/seed/models.db`:** 3 sources, 3,259 repos, 32,779 artifacts (down from 33,736 as adapters/junk were removed).

## Validation
- New `tests/registry-ingestor-quality.test.js` (adapter exclusion, consolidated kept, bf16-not-quant, GPT4All comma size + HF-backed canonical id). Verified on the regenerated seed: 0 adapter artifacts, 0 dead index. Full suite **48/48**. Bumps to **3.7.4**.

## Still deferred (lower value)
Shard row-aggregation (the ~16x HF shard inflation) — correctness is already handled by the recommender (3.7.2 ignores per-shard size + collapses display); aggregating at ingest would shrink the seed but needs the min-artifacts gate reworked. Also the dead `better-sqlite3` branch and duplicated `inferFamily` (cosmetic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)