### PR TITLE
feat(cli): search/list-models can query the multi-source registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ llm-checker search "qwen coder" --json
 | `recommend` | Intelligent recommendations by category (coding, reasoning, multimodal, etc.) |
 | `calibrate` | Generate calibration result + routing policy artifacts from a JSONL prompt suite |
 | `installed` | Rank your installed Ollama models by compatibility |
-| `list-models` | List the synced Ollama catalog by popularity, category, size, or JSON output |
+| `list-models` | List the synced Ollama catalog by popularity, category, size, or JSON output (add `--registry`/`--source` to list the multi-source registry) |
 | `ollama-plan` | Compute safe Ollama runtime env vars (`NUM_CTX`, `NUM_PARALLEL`, `MAX_LOADED_MODELS`) for selected local models |
 | `mcp-setup` | Print/apply Claude MCP setup command and config snippet (`--apply`, `--json`, `--npx`) |
 | `gpu-plan` | Multi-GPU placement advisor with single/pooled model-size envelopes |
@@ -395,7 +395,7 @@ llm-checker search "qwen coder" --json
 | Command | Description |
 |---------|-------------|
 | `sync` | Refresh the local SQLite model catalog from Ollama |
-| `search <query>` | Search the synced catalog with filters and intelligent scoring |
+| `search <query>` | Search the synced Ollama catalog; add `--registry`/`--source` to search the multi-source registry (HF + Ollama + GPT4All) with `--max-params`/`--runtime`/`--format` filters |
 | `smart-recommend` | Advanced recommendations using the full scoring engine |
 
 ### Model Registry Commands (v3.7.0+)

--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -463,6 +463,92 @@ function formatRegistryList(value, maxItems = 3) {
     return items.length > maxItems ? `${shown}, +${items.length - maxItems}` : shown;
 }
 
+// Shared multi-source registry search used by `registry-search` and by
+// `search`/`list-models` when run with `--registry`/`--source`. Searches the
+// packaged registry of HF + Ollama + GPT4All artifacts (not just the Ollama
+// catalog). Renders a table or JSON. Sets process.exitCode on validation error.
+async function executeRegistrySearch(query = '', options = {}) {
+    try {
+        validateRegistryFilters(options);
+    } catch (validationError) {
+        if (options.json) {
+            console.log(JSON.stringify({ error: validationError.message }, null, 2));
+        } else {
+            console.error(chalk.red(`✗ ${validationError.message}`));
+        }
+        process.exitCode = 1;
+        return;
+    }
+    if (!options.json) showAsciiArt('registry-search');
+
+    const ModelDatabase = require('../src/data/model-database');
+    const database = new ModelDatabase();
+
+    try {
+        await database.initialize();
+
+        const filters = {
+            source: options.source,
+            format: options.format ? String(options.format).toLowerCase() : undefined,
+            runtime: options.runtime,
+            quantization: options.quant,
+            maxSizeGB: parsePositiveNumberOption(options.maxSize),
+            minParamsB: parsePositiveNumberOption(options.minParams),
+            maxParamsB: parsePositiveNumberOption(options.maxParams),
+            localOnly: Boolean(options.localOnly),
+            limit: parsePositiveNumberOption(options.limit, 20)
+        };
+        const results = database.searchModelArtifacts(query, filters);
+        const stats = database.getRegistryStats();
+
+        if (options.json) {
+            console.log(JSON.stringify({ query, filters, count: results.length, stats, results }, null, 2));
+            return;
+        }
+
+        if (results.length === 0) {
+            console.log(chalk.yellow('No registry artifacts found.'));
+            if (stats.artifacts === 0) {
+                console.log(chalk.gray('Populate the registry first with: llm-checker registry-sync'));
+            }
+            return;
+        }
+
+        console.log(chalk.blue.bold('\nRegistry Results'));
+        console.log(chalk.gray(`Stored registry: ${stats.artifacts} artifacts across ${stats.sources} sources`));
+        console.log('');
+
+        const rows = [['Source', 'Model', 'Artifact', 'Params', 'Size', 'Format', 'Runtime', 'Install']];
+        for (const item of results) {
+            rows.push([
+                item.source_id,
+                truncateMiddle(item.canonical_model_id, 34),
+                truncateMiddle(item.artifact_name || item.filename, 34),
+                formatRegistryNumber(item.parameter_count_b, 'B'),
+                formatRegistrySize(item.size_gb),
+                item.quantization ? `${item.format}/${item.quantization}` : item.format,
+                formatRegistryList(item.runtime_support, 2),
+                truncateMiddle(item.install_command || item.download_url, 46)
+            ]);
+        }
+        console.log(table(rows));
+
+        const links = results.filter((item) => item.download_url).slice(0, 5);
+        if (links.length > 0) {
+            console.log(chalk.blue.bold('Exact download links:'));
+            links.forEach((item, index) => {
+                console.log(chalk.gray(`  ${index + 1}. ${item.canonical_model_id} -> ${item.download_url}`));
+            });
+        }
+    } catch (error) {
+        console.error(chalk.red('Error:'), error.message);
+        if (process.env.DEBUG) console.error(error.stack);
+        process.exitCode = 1;
+    } finally {
+        database.close();
+    }
+}
+
 const program = new Command();
 
 program
@@ -4269,15 +4355,25 @@ Custom hardware:
 
 program
     .command('list-models')
-    .description('List all models from Ollama database')
+    .description('List models (Ollama catalog by default; --registry/--source lists HF + Ollama + GPT4All)')
     .option('-c, --category <category>', 'Filter by category (coding, talking, reading, reasoning, multimodal, creative, general)')
     .option('-s, --size <size>', 'Filter by size (small, medium, large, e.g., "7b", "13b")')
     .option('-p, --popular', 'Show only popular models (>100k pulls)')
     .option('-r, --recent', 'Show only recent models (updated in last 30 days)')
+    .option('--registry', 'List from the multi-source registry (Hugging Face + Ollama + GPT4All)')
+    .option('--source <source>', 'Registry source filter (implies --registry): ollama, huggingface, gpt4all')
+    .option('--format <format>', 'Registry artifact format: gguf, safetensors, mlx, ollama')
+    .option('--runtime <runtime>', 'Registry runtime: auto, ollama, llama.cpp, transformers, vllm, mlx')
     .option('--limit <number>', 'Limit number of results (default: 50)', '50')
     .option('--full', 'Show full details including variants and tags')
     .option('--json', 'Output in JSON format')
     .action(async (options) => {
+        // Registry mode: list the packaged multi-source registry instead of the
+        // Ollama-only catalog.
+        if (options.registry || options.source) {
+            await executeRegistrySearch('', options);
+            return;
+        }
         if (!options.json) showAsciiArt('list-models');
         const spinner = options.json ? null : ora('📋 Loading models database...').start();
 
@@ -4910,104 +5006,7 @@ program
     .option('-l, --limit <n>', 'Maximum number of results', '20')
     .option('-j, --json', 'Output as JSON')
     .action(async (query = '', options) => {
-        try {
-            validateRegistryFilters(options);
-        } catch (validationError) {
-            if (options.json) {
-                console.log(JSON.stringify({ error: validationError.message }, null, 2));
-            } else {
-                console.error(chalk.red(`✗ ${validationError.message}`));
-            }
-            process.exitCode = 1;
-            return;
-        }
-        if (!options.json) showAsciiArt('registry-search');
-
-        const ModelDatabase = require('../src/data/model-database');
-        const database = new ModelDatabase();
-
-        try {
-            await database.initialize();
-
-            const filters = {
-                source: options.source,
-                format: options.format ? String(options.format).toLowerCase() : undefined,
-                runtime: options.runtime,
-                quantization: options.quant,
-                maxSizeGB: parsePositiveNumberOption(options.maxSize),
-                minParamsB: parsePositiveNumberOption(options.minParams),
-                maxParamsB: parsePositiveNumberOption(options.maxParams),
-                localOnly: Boolean(options.localOnly),
-                limit: parsePositiveNumberOption(options.limit, 20)
-            };
-            const results = database.searchModelArtifacts(query, filters);
-            const stats = database.getRegistryStats();
-
-            if (options.json) {
-                console.log(JSON.stringify({
-                    query,
-                    filters,
-                    count: results.length,
-                    stats,
-                    results
-                }, null, 2));
-                return;
-            }
-
-            if (results.length === 0) {
-                console.log(chalk.yellow('No registry artifacts found.'));
-                if (stats.artifacts === 0) {
-                    console.log(chalk.gray('Populate the registry first with: llm-checker registry-sync'));
-                }
-                return;
-            }
-
-            console.log(chalk.blue.bold('\nRegistry Results'));
-            console.log(chalk.gray(`Stored registry: ${stats.artifacts} artifacts across ${stats.sources} sources`));
-            console.log('');
-
-            const rows = [[
-                'Source',
-                'Model',
-                'Artifact',
-                'Params',
-                'Size',
-                'Format',
-                'Runtime',
-                'Install'
-            ]];
-
-            for (const item of results) {
-                rows.push([
-                    item.source_id,
-                    truncateMiddle(item.canonical_model_id, 34),
-                    truncateMiddle(item.artifact_name || item.filename, 34),
-                    formatRegistryNumber(item.parameter_count_b, 'B'),
-                    formatRegistrySize(item.size_gb),
-                    item.quantization ? `${item.format}/${item.quantization}` : item.format,
-                    formatRegistryList(item.runtime_support, 2),
-                    truncateMiddle(item.install_command || item.download_url, 46)
-                ]);
-            }
-
-            console.log(table(rows));
-
-            const links = results
-                .filter((item) => item.download_url)
-                .slice(0, 5);
-            if (links.length > 0) {
-                console.log(chalk.blue.bold('Exact download links:'));
-                links.forEach((item, index) => {
-                    console.log(chalk.gray(`  ${index + 1}. ${item.canonical_model_id} -> ${item.download_url}`));
-                });
-            }
-        } catch (error) {
-            console.error(chalk.red('Error:'), error.message);
-            if (process.env.DEBUG) console.error(error.stack);
-            process.exitCode = 1;
-        } finally {
-            database.close();
-        }
+        await executeRegistrySearch(query, options);
     });
 
 program
@@ -5133,15 +5132,27 @@ program
 
 program
     .command('search <query>')
-    .description('Search models in the database with intelligent scoring')
+    .description('Search models (Ollama catalog by default; --registry/--source searches HF + Ollama + GPT4All)')
     .option('-u, --use-case <case>', 'Optimize for use case (general, coding, chat, reasoning, creative)', 'general')
     .option('-l, --limit <n>', 'Maximum number of results', '10')
     .option('--max-size <gb>', 'Maximum model size in GB')
     .option('--min-size <gb>', 'Minimum model size in GB')
     .option('--quant <type>', 'Filter by quantization (Q4_K_M, Q5_K_M, Q8_0, etc.)')
     .option('--family <name>', 'Filter by model family (llama, qwen, mistral, etc.)')
+    .option('--registry', 'Search the multi-source registry (Hugging Face + Ollama + GPT4All)')
+    .option('-s, --source <source>', 'Registry source filter (implies --registry): ollama, huggingface, gpt4all')
+    .option('--format <format>', 'Registry artifact format: gguf, safetensors, mlx, ollama')
+    .option('--runtime <runtime>', 'Registry runtime: auto, ollama, llama.cpp, transformers, vllm, mlx')
+    .option('--min-params <billion>', 'Minimum parameter count in billions (registry mode)')
+    .option('--max-params <billion>', 'Maximum parameter count in billions (registry mode)')
     .option('-j, --json', 'Output as JSON')
     .action(async (query, options) => {
+        // Registry mode: search the packaged multi-source registry (HF + Ollama +
+        // GPT4All) instead of the Ollama-only catalog.
+        if (options.registry || options.source) {
+            await executeRegistrySearch(query, options);
+            return;
+        }
         if (!options.json) showAsciiArt('search');
         const SyncManager = require('../src/data/sync-manager');
         const IntelligentSelector = require('../src/models/intelligent-selector');

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,6 +1,23 @@
 Changelog
 =========
 
+3.7.5 — Registry in search / list-models (2026-06-20)
+-----------------------------------------------------
+
+The discovery commands can now reach the multi-source registry, not just the
+Ollama catalog:
+
+- `search <query> --registry` (or `--source <ollama|huggingface|gpt4all>`)
+  searches the packaged registry of HF + Ollama + GPT4All artifacts, with
+  `--max-params`/`--min-params`/`--runtime`/`--format`/`--quant`/`--max-size`
+  filters and exact install commands. Without `--registry`/`--source` it keeps
+  the original Ollama-catalog behavior (backward compatible).
+- `list-models --registry` / `--source <source>` lists the multi-source registry.
+- The registry search logic is now shared between `registry-search` and
+  `search`/`list-models` (one code path, enum validation included).
+
+New tests in `tests/registry-cli-validation.test.js`. Full suite 48/48.
+
 3.7.4 — Registry Ingestor Data Quality (2026-06-20)
 ---------------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.7.4",
+      "version": "3.7.5",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.7.4",
+  "version": "3.7.5",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",

--- a/tests/registry-cli-validation.test.js
+++ b/tests/registry-cli-validation.test.js
@@ -63,8 +63,40 @@ async function testEmptyPoolDoesNotFallBackToInternalCatalog() {
     assert.deepStrictEqual(out.recommendations, [], 'empty pool yields no recommendations (not internal-catalog rows)');
 }
 
+function testSearchRegistryModeUsesRegistry() {
+    // `search --registry` searches the multi-source registry (registry JSON shape
+    // has `stats`/`count`), and can surface non-Ollama sources.
+    const { status, stdout } = runCli(['search', 'qwen', '--registry', '--source', 'huggingface', '--json', '--limit', '2']);
+    assert.strictEqual(status, 0, 'search --registry exits 0');
+    const payload = JSON.parse(stdout);
+    assert.ok('stats' in payload && 'count' in payload, 'registry mode returns the registry JSON shape');
+    const sources = new Set((payload.results || []).map((r) => r.source_id));
+    assert.ok(sources.size === 0 || sources.has('huggingface'), 'source filter restricts to huggingface');
+}
+
+function testPlainSearchStaysOllamaCatalog() {
+    // Without --registry/--source, search keeps its original Ollama-catalog shape
+    // (no registry `stats` field) — backward compatible.
+    const { status, stdout } = runCli(['search', 'llama', '--json', '--limit', '2']);
+    assert.strictEqual(status, 0, 'plain search exits 0');
+    const payload = JSON.parse(stdout);
+    assert.ok(!(payload && typeof payload === 'object' && 'stats' in payload), 'plain search must not use registry shape');
+}
+
+function testListModelsRegistrySource() {
+    const { status, stdout } = runCli(['list-models', '--source', 'gpt4all', '--json', '--limit', '2']);
+    assert.strictEqual(status, 0, 'list-models --source exits 0');
+    const payload = JSON.parse(stdout);
+    assert.ok('stats' in payload, 'list-models --source returns registry shape');
+    const sources = new Set((payload.results || []).map((r) => r.source_id));
+    assert.ok(sources.size === 0 || sources.has('gpt4all'), 'restricted to gpt4all');
+}
+
 async function run() {
     testInvalidSourceRejected();
+    testSearchRegistryModeUsesRegistry();
+    testPlainSearchStaysOllamaCatalog();
+    testListModelsRegistrySource();
     testInvalidRuntimeRejected();
     testValidSourceAccepted();
     await testEmptyPoolDoesNotFallBackToInternalCatalog();


### PR DESCRIPTION
## Why
`search` and `list-models` only hit the Ollama-synced catalog, so the ~32k HuggingFace/Ollama/GPT4All registry was invisible unless you knew the separate `registry-*` commands. (Reported: "I only see Ollama when we read a lot from HuggingFace.")

## What changed
- `search <query> --registry` (or `--source <ollama|huggingface|gpt4all>`) now searches the **multi-source registry**, with `--max-params`/`--min-params`/`--runtime`/`--format`/`--quant`/`--max-size` filters and exact install commands (`hf download …`, `ollama pull …`).
- `list-models --registry` / `--source <source>` lists the registry.
- **Backward compatible:** without `--registry`/`--source`, both commands keep their original Ollama-catalog behavior.
- Refactor: extracted the registry search+render into one shared `executeRegistrySearch()` used by `registry-search` and the new `search`/`list-models` paths (enum validation included, so invalid `--source/--format/--runtime` are rejected consistently).

## Examples
```bash
llm-checker search qwen --registry --source huggingface --max-params 24 --runtime vllm
llm-checker list-models --source gpt4all
```

## Validation
- New cases in `tests/registry-cli-validation.test.js`: `search --registry` returns the registry shape and respects `--source`; plain `search` stays on the Ollama catalog (backward compat); `list-models --source` lists the registry. Full suite **48/48**. Bumps to **3.7.5**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)