### PR TITLE
fix(hardware): ignore virtual display adapters in GPU detection (#106)

### DIFF
--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+3.7.6 — Virtual-monitor GPU detection fix (2026-06-22)
+-----------------------------------------------------
+
+- Fixed #106: virtual display adapters created by streaming hosts (Apollo/Sunshine
+  via IddSampleDriver), VR headsets (Meta Quest, Oculus), and remote-desktop tools
+  (Parsec, spacedesk, Splashtop) were being counted as dedicated GPUs. That faked
+  multi-GPU and buried the real card — a Radeon RX 7900 XTX was ignored, leaving
+  CPU-only results. These adapters are now filtered from GPU detection (both the
+  unified detector's Windows fallback/inventory and the legacy detector), while
+  real GPUs — including an Intel "Apollo Lake" iGPU and rare vGPUs with a real-GPU
+  signature — are kept.
+- New `tests/virtual-monitor-gpu-detection.test.js`. Full suite 49/49.
+
 3.7.5 — Registry in search / list-models (2026-06-20)
 -----------------------------------------------------
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.7.5",
+      "version": "3.7.6",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.7.5",
+  "version": "3.7.6",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",

--- a/src/hardware/detector.js
+++ b/src/hardware/detector.js
@@ -202,7 +202,14 @@ class HardwareDetector {
             ) {
                 return false;
             }
-            
+
+            // Skip virtual display adapters (streaming hosts, VR headsets, remote
+            // desktop) that are not physical compute GPUs and otherwise bury the
+            // real card (issue #106: Apollo + Quest 2 virtual monitors).
+            if (this.isVirtualDisplayAdapter(model)) {
+                return false;
+            }
+
             return true;
         });
 
@@ -476,6 +483,21 @@ class HardwareDetector {
         } else {
             return process.arch || 'Unknown';
         }
+    }
+
+    // Virtual / non-physical display adapters (streaming hosts via IddSampleDriver,
+    // VR headsets, remote-desktop tools) that must not be treated as compute GPUs.
+    isVirtualDisplayAdapter(model) {
+        const lower = String(model || '').toLowerCase();
+        if (!lower) return false;
+        const markers = [
+            'iddsampledriver', 'indirect display', 'idd device',
+            'meta quest', 'oculus', 'parsec', 'spacedesk', 'splashtop',
+            'rainway', 'dummy display', 'usb display adapter'
+        ];
+        if (markers.some((marker) => lower.includes(marker))) return true;
+        const realGpuSignature = /(geforce|radeon\s*(\(tm\))?\s*rx|\brx\s?\d|rtx|gtx|quadro|tesla|instinct|\barc\b|a\d{3,}|h100|a100|l40|mi\d{2,})/i;
+        return lower.includes('virtual') && !realGpuSignature.test(lower);
     }
 
     isIntegratedGPU(model) {

--- a/src/hardware/unified-detector.js
+++ b/src/hardware/unified-detector.js
@@ -496,15 +496,40 @@ class UnifiedDetector {
             .filter(Boolean);
     }
 
+    // True for adapters that are NOT physical compute GPUs and must be excluded
+    // from the GPU inventory: remote/basic display drivers, and virtual display
+    // adapters created by streaming hosts (Apollo/Sunshine via IddSampleDriver),
+    // VR headsets (Meta Quest, Oculus), and remote-desktop tools (Parsec, spacedesk).
+    // These otherwise get mis-counted as dedicated GPUs and bury the real card.
     isRemoteDisplayModel(model) {
         const lower = String(model || '').toLowerCase();
         if (!lower) return false;
 
-        return (
-            lower.includes('microsoft remote display adapter') ||
-            lower.includes('remote display adapter') ||
-            lower.includes('basic render driver')
-        );
+        // Explicit non-GPU display-adapter markers (some don't contain "virtual").
+        const markers = [
+            'remote display adapter',
+            'basic render driver',
+            'iddsampledriver',
+            'indirect display',
+            'idd device',
+            'meta quest',
+            'oculus',
+            'parsec',
+            'spacedesk',
+            'splashtop',
+            'rainway',
+            'dummy display',
+            'usb display adapter'
+        ];
+        if (markers.some((marker) => lower.includes(marker))) return true;
+
+        // Generic "virtual" display/monitor adapters (e.g. "Apollo Virtual Monitor",
+        // "Meta Quest Virtual Monitor"). A real discrete GPU never has "virtual" in
+        // its name; guard against the rare vGPU named with a real-GPU signature.
+        const realGpuSignature = /(geforce|radeon\s*(\(tm\))?\s*rx|\brx\s?\d|rtx|gtx|quadro|tesla|instinct|\barc\b|a\d{3,}|h100|a100|l40|mi\d{2,})/i;
+        if (lower.includes('virtual') && !realGpuSignature.test(lower)) return true;
+
+        return false;
     }
 
     inferGpuVendor(name) {

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -15,6 +15,7 @@ const TESTS = [
     { name: 'ROCm VRAM parsing regression', file: 'rocm-vram-parsing.test.js', category: 'Hardware' },
     { name: 'High-end / multi-GPU VRAM detection', file: 'hardware-vram-highend.test.js', category: 'Hardware' },
     { name: 'CPU detector Windows fallback', file: 'cpu-detector-windows-fallback.test.js', category: 'Hardware' },
+    { name: 'Virtual-monitor GPU detection', file: 'virtual-monitor-gpu-detection.test.js', category: 'Hardware' },
     { name: 'Termux platform support', file: 'termux-platform-support.test.js', category: 'Hardware' },
     { name: 'Token speed estimation', file: 'token-speed-estimation.test.js', category: 'Performance' },
     { name: 'Deterministic model pool', file: 'deterministic-model-pool-check.js', category: 'Recommendations' },

--- a/tests/virtual-monitor-gpu-detection.test.js
+++ b/tests/virtual-monitor-gpu-detection.test.js
@@ -1,0 +1,94 @@
+/**
+ * Virtual-monitor GPU detection regression (issue #106)
+ * =====================================================
+ * Virtual display adapters from streaming hosts (Apollo/Sunshine via
+ * IddSampleDriver), VR headsets (Meta Quest, Oculus), and remote-desktop tools
+ * (Parsec, spacedesk) were classified as dedicated GPUs, faking multi-GPU and
+ * burying the real card (a Radeon RX 7900 XTX), leaving CPU-only results.
+ */
+
+const assert = require('assert');
+const UnifiedDetector = require('../src/hardware/unified-detector');
+const HardwareDetector = require('../src/hardware/detector');
+
+const VIRTUAL = [
+    'Apollo Virtual Monitor',
+    'Meta Quest Virtual Monitor',
+    'IddSampleDriver Device',
+    'Oculus Virtual Audio Device',
+    'Virtual Display Driver',
+    'Parsec Virtual Display Adapter',
+    'spacedesk Graphics Adapter'
+];
+
+// Real GPUs (and a real Intel "Apollo Lake" iGPU) must NOT be filtered.
+const REAL = [
+    'AMD Radeon(TM) RX 7900 XTX',
+    'AMD Radeon RX 7900 XTX',
+    'NVIDIA GeForce RTX 4090',
+    'Intel HD Graphics 500 (Apollo Lake)',
+    'Intel Arc A770',
+    'NVIDIA A100-SXM4-80GB'
+];
+
+function testUnifiedFilterClassification() {
+    const u = new UnifiedDetector();
+    for (const name of VIRTUAL) {
+        assert.strictEqual(u.isRemoteDisplayModel(name), true, `virtual adapter must be filtered: ${name}`);
+    }
+    for (const name of REAL) {
+        assert.strictEqual(u.isRemoteDisplayModel(name), false, `real GPU must NOT be filtered: ${name}`);
+    }
+}
+
+function testNormalizeGpuInventoryDropsVirtual() {
+    const u = new UnifiedDetector();
+    const inventory = [
+        { name: 'Apollo Virtual Monitor', type: 'dedicated', memory: { total: 0 } },
+        { name: 'Meta Quest Virtual Monitor', type: 'dedicated', memory: { total: 0 } },
+        { name: 'AMD Radeon RX 7900 XTX', type: 'dedicated', memory: { total: 24 } }
+    ];
+    const out = u.normalizeGpuInventory(inventory);
+    assert.strictEqual(out.length, 1, 'only the real GPU survives');
+    assert.ok(/7900 xtx/i.test(out[0].name), 'the surviving GPU is the 7900 XTX');
+}
+
+function testDetectorFilterAndPrimary() {
+    const d = new HardwareDetector();
+    for (const name of VIRTUAL) {
+        assert.strictEqual(d.isVirtualDisplayAdapter(name), true, `detector must flag virtual: ${name}`);
+    }
+    assert.strictEqual(d.isVirtualDisplayAdapter('Intel HD Graphics 500 (Apollo Lake)'), false, 'real iGPU kept');
+
+    // Virtual monitors listed FIRST must not displace the real dedicated GPU.
+    const graphics = { controllers: [
+        { model: 'Apollo Virtual Monitor', vendor: '', vram: 0 },
+        { model: 'Meta Quest Virtual Monitor', vendor: '', vram: 0 },
+        { model: 'IddSampleDriver Device', vendor: '', vram: 0 },
+        { model: 'AMD Radeon(TM) RX 7900 XTX', vendor: 'Advanced Micro Devices, Inc.', vram: 0 }
+    ]};
+    const gpu = d.processGPUInfo(graphics, { total: 32 * 1024 ** 3 });
+    assert.ok(/7900 xtx/i.test(gpu.model), `primary must be the 7900 XTX, got ${gpu.model}`);
+    assert.strictEqual(gpu.dedicated, true, 'primary is dedicated');
+    assert.ok(gpu.vram >= 24, `7900 XTX VRAM must be ~24GB, got ${gpu.vram}`);
+    assert.ok(!gpu.isMultiGPU, 'virtual monitors must not fake multi-GPU');
+}
+
+function run() {
+    testUnifiedFilterClassification();
+    testNormalizeGpuInventoryDropsVirtual();
+    testDetectorFilterAndPrimary();
+    console.log('virtual-monitor-gpu-detection.test.js: OK');
+}
+
+if (require.main === module) {
+    try {
+        run();
+    } catch (error) {
+        console.error('virtual-monitor-gpu-detection.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    }
+}
+
+module.exports = { run };


### PR DESCRIPTION
Fixes #106.

## Problem
On Windows, virtual display adapters created by **Apollo/Sunshine** (via IddSampleDriver), a **Quest 2 / Meta** headset, and remote-desktop tools were enumerated as GPUs. The detector classified them as **dedicated GPUs with 0 VRAM**, which faked multi-GPU and buried the user's real **Radeon RX 7900 XTX** — so the checker ignored the 24GB card and returned **CPU-only** results. (Disabling the devices in Device Manager didn't help; they're still enumerated.)

## Root cause
`isRemoteDisplayModel` (the shared filter used by the unified detector's Windows `systeminformation` fallback and inventory normalization) only matched "remote display adapter" / "basic render driver". Apollo/Quest/IDD adapters slipped through → counted as dedicated GPUs.

## Fix
- Expanded `isRemoteDisplayModel` (unified detector) and added `isVirtualDisplayAdapter` (legacy detector) to drop virtual/streaming/VR/remote display adapters: `iddsampledriver`, `indirect display`, `meta quest`, `oculus`, `parsec`, `spacedesk`, `splashtop`, and generic `virtual` display/monitor names.
- **Guarded against false positives:** a real Intel "Apollo **Lake**" iGPU and rare vGPUs carrying a real-GPU signature (`geforce`/`rtx`/`radeon rx`/`arc`/`a100`/…) are **not** filtered.

After the fix, with the virtual monitors listed first, the **7900 XTX is the dedicated primary (24GB), `isMultiGPU` is false**.

## Validation
- New `tests/virtual-monitor-gpu-detection.test.js`: asserts all the virtual adapters are filtered, real GPUs (incl. Apollo Lake iGPU, Arc, A100) are kept, the inventory drops virtual entries, and the 7900 XTX wins as dedicated primary.
- Full suite **49/49**. Bumps to **3.7.6**.

> Note: this restores detection of the dedicated AMD card. Actual AMD inference on Windows still depends on the runtime (ROCm/Vulkan); that's separate from detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)