### PR TITLE
feat: harden ModelVet release and credit Tetsuo AI

### DIFF
--- a/.github/workflows/policy-gate.yml
+++ b/.github/workflows/policy-gate.yml
@@ -8,6 +8,38 @@ on:
       - master
 
 jobs:
+  test-suite:
+    name: Full test suite (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [18, 20, 22]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Audit production dependencies
+        if: matrix.node-version == 20
+        run: npm audit --omit=dev
+
+      - name: Run full test suite
+        run: npm test
+
+      - name: Verify npm package contents
+        if: matrix.node-version == 20
+        run: npm pack --dry-run
+
   policy-gate:
     runs-on: ubuntu-latest
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ Choosing the right LLM for your hardware is complex. With thousands of model var
 | **Zero** | Native Dependencies | Pure JavaScript &mdash; works on any supported Node.js 18+ system |
 | **Live** | AI Run Metrics | `ai-run` shows response speed in tokens/sec next to model output |
 
+> **ModelVet credit:** The structural verification behind `verify`,
+> `ai-run --verify`, structural policy validation, and the MCP `verify_model` tool is
+> powered by [ModelVet](https://github.com/tetsuo-ai/modelvet), created by
+> [Tetsuo AI](https://github.com/tetsuo-ai). LLM Checker ships its WebAssembly
+> integration under ModelVet's MIT license.
+
 ---
 
 ## Documentation
@@ -410,10 +416,12 @@ llm-checker verify ~/.ollama/models/blobs/sha256-abc123...
 llm-checker verify ./model.safetensors --json
 ```
 
-`verify` runs [modelvet](https://github.com/tetsuo-ai/modelvet) — a structural
-safety validator for GGUF and safetensors files — compiled to WebAssembly and
-shipped inside the npm package, so it stays pure JavaScript with zero native
-dependencies and works offline on every supported platform.
+`verify` is powered by [ModelVet](https://github.com/tetsuo-ai/modelvet), the
+structural safety validator for GGUF and safetensors developed by
+[Tetsuo AI](https://github.com/tetsuo-ai). LLM Checker packages ModelVet as
+WebAssembly and integrates it with the CLI, Ollama verification gates,
+policies, and MCP, keeping verification offline and free of native
+dependencies.
 
 It answers one question before any model loader touches a file: *is this file
 structurally safe to load?* Every file-derived length, count, offset, and
@@ -437,6 +445,8 @@ wasm32 memory ceiling; use the native modelvet CLI for those.
 
 The vendored source and rebuild instructions live in
 [`vendor/modelvet/`](vendor/modelvet/README.md).
+License and attribution details are in
+[THIRD_PARTY_NOTICES](https://github.com/signerless/llm-checker/blob/main/THIRD_PARTY_NOTICES).
 
 #### Verification Gates in Ollama Flows
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLM Checker
 
-![LLM Checker Animated Logo](https://raw.githubusercontent.com/Pavelevich/llm-checker/main/assets/llm-checker-logo.gif)
+![LLM Checker Animated Logo](https://raw.githubusercontent.com/signerless/llm-checker/main/assets/llm-checker-logo.gif)
 
 **Intelligent Ollama Model Selector**
 
@@ -11,13 +11,13 @@ Deterministic scoring across a packaged **multi-source registry** (Hugging Face 
 [![npm downloads](https://img.shields.io/npm/dm/llm-checker?style=flat-square&color=0066FF)](https://www.npmjs.com/package/llm-checker)
 [![License](https://img.shields.io/badge/License-NPDL--1.0-CC3300?style=flat-square)](LICENSE)
 [![Discord](https://img.shields.io/discord/1457032977849520374?style=flat-square&color=0066FF&label=Discord)](https://discord.gg/mnmYrA7T)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D16-0066FF?style=flat-square)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/node-%3E%3D18-0066FF?style=flat-square)](https://nodejs.org/)
 
 [Start Here](#start-here-2-minutes) •
 [Installation](#installation) •
 [Quick Start](#quick-start) •
 [Calibration Quick Start](#calibration-quick-start-10-minutes) •
-[Docs](https://github.com/Pavelevich/llm-checker/tree/main/docs) •
+[Docs](https://github.com/signerless/llm-checker/tree/main/docs) •
 [Claude MCP](#claude-code-mcp) •
 [Commands](#commands) •
 [Scoring](#scoring-system) •
@@ -43,19 +43,19 @@ Choosing the right LLM for your hardware is complex. With thousands of model var
 | **4D** | Scoring Engine | Quality, Speed, Fit, Context &mdash; weighted by use case |
 | **Multi-GPU** | Hardware Detection | Apple Silicon, NVIDIA CUDA, AMD ROCm, Intel Arc, CPU, integrated/dedicated inventory visibility |
 | **Calibrated** | Memory Estimation | Bytes-per-parameter formula validated against real Ollama sizes |
-| **Zero** | Native Dependencies | Pure JavaScript &mdash; works on any Node.js 16+ system |
+| **Zero** | Native Dependencies | Pure JavaScript &mdash; works on any supported Node.js 18+ system |
 | **Live** | AI Run Metrics | `ai-run` shows response speed in tokens/sec next to model output |
 
 ---
 
 ## Documentation
 
-- [Docs Hub](https://github.com/Pavelevich/llm-checker/tree/main/docs)
-- [Usage Guide](https://github.com/Pavelevich/llm-checker/blob/main/docs/guides/usage-guide.md)
-- [Advanced Usage](https://github.com/Pavelevich/llm-checker/blob/main/docs/guides/advanced-usage.md)
-- [Technical Reference](https://github.com/Pavelevich/llm-checker/blob/main/docs/reference/technical-docs.md)
-- [Changelog](https://github.com/Pavelevich/llm-checker/blob/main/docs/reference/changelog.md)
-- [Calibration Fixtures](https://github.com/Pavelevich/llm-checker/tree/main/docs/fixtures/calibration)
+- [Docs Hub](https://github.com/signerless/llm-checker/tree/main/docs)
+- [Usage Guide](https://github.com/signerless/llm-checker/blob/main/docs/guides/usage-guide.md)
+- [Advanced Usage](https://github.com/signerless/llm-checker/blob/main/docs/guides/advanced-usage.md)
+- [Technical Reference](https://github.com/signerless/llm-checker/blob/main/docs/reference/technical-docs.md)
+- [Changelog](https://github.com/signerless/llm-checker/blob/main/docs/reference/changelog.md)
+- [Calibration Fixtures](https://github.com/signerless/llm-checker/tree/main/docs/fixtures/calibration)
 
 ---
 
@@ -91,7 +91,7 @@ npm install -g llm-checker
 ```
 
 **Requirements:**
-- Node.js 16+ (any version: 16, 18, 20, 22, 24)
+- Node.js 18+ (tested release lines: 18, 20, 22)
 - [Ollama](https://ollama.ai) installed for running models
 
 The package includes a prebuilt model catalog and declares `sql.js` as an optional dependency for SQLite-powered commands. If your package manager skips optional dependencies and database commands report `sql.js` missing, reinstall with optional dependencies enabled:
@@ -136,7 +136,7 @@ llm-checker ai-run --calibrated --category coding --prompt "Refactor this functi
 LLM Checker is published in all primary channels:
 
 - npm (latest, recommended): [`llm-checker@latest`](https://www.npmjs.com/package/llm-checker)
-- GitHub Releases: [Release history](https://github.com/Pavelevich/llm-checker/releases)
+- GitHub Releases: [Release history](https://github.com/signerless/llm-checker/releases)
 - GitHub Packages (legacy mirror, may lag): [`@pavelevich/llm-checker`](https://github.com/users/Pavelevich/packages/npm/package/llm-checker)
 
 ### Important: Use npm for Latest Builds
@@ -287,8 +287,14 @@ llm-checker mcp-setup --client generic   # raw mcpServers JSON for any client
 ```
 
 `--apply` merges the server entry into the client's config file (existing
-content is never clobbered), `--npx` uses `npx llm-checker-mcp` instead of a
-global install, and `--json` prints the structured snippet for scripting.
+content is never clobbered), and `--json` prints the structured snippet for
+scripting. `--npx` avoids a global server install by generating the explicit
+package-qualified command below (the executable is part of `llm-checker`; there
+is no separate `llm-checker-mcp` npm package):
+
+```bash
+npx --yes --package llm-checker llm-checker-mcp
+```
 
 Restart your client and you're done.
 
@@ -306,12 +312,16 @@ Once connected, your assistant can use these tools:
 | `installed` | Rank your already-downloaded Ollama models |
 | `search` | Search the Ollama model catalog with filters |
 | `smart_recommend` | Advanced recommendations using the full scoring engine |
+| `gpu_plan` | Plan safe single/multi-GPU model placement and runtime settings |
+| `verify_context` | Check a local model's practical context limit against available memory |
 | `ollama_plan` | Build a capacity plan for local models with recommended context/parallel/memory settings |
 | `ollama_plan_env` | Return ready-to-paste `export ...` env vars from the recommended or fallback plan profile |
 | `policy_validate` | Validate a policy file against the v1 schema and return structured validation output |
 | `audit_export` | Run policy compliance export (`json`/`csv`/`sarif`/`all`) for `check` or `recommend` flows |
 | `calibrate` | Generate calibration artifacts from a prompt suite with typed MCP inputs |
 | `verify_model` | Structural safety validation of a GGUF/safetensors file (modelvet) — verify-before-load |
+| `amd_guard` | Run AMD/Windows reliability checks and return mitigation guidance |
+| `toolcheck` | Test tool-calling compatibility for local Ollama models |
 
 **Ollama Management:**
 
@@ -412,7 +422,7 @@ tensor size is checked with overflow-safe arithmetic, in fixed memory.
 ```
 === Model Verification (modelvet) ===
 File:      ./suspicious.gguf
-Format:    gguf (4.36 GiB)
+Format:    gguf (0.12 GiB)
 Verdict:   REJECT
 Violation: TENSOR_DATA_EXTENT (code 311)
 Offset:    0x1a4f2
@@ -439,14 +449,18 @@ llm-checker installed --verify --json
 
 # Verify the selected model's blob after pull, before running it
 llm-checker ai-run --verify --category coding --prompt "Refactor this function"
+
+# Explicitly continue only if verification is unavailable (never on REJECT)
+llm-checker ai-run --verify --allow-unverified --category coding --prompt "Refactor this function"
 ```
 
 - `installed --verify` adds a per-model verification status (verified /
   REJECTED with the violation name / skipped with reason). Any REJECT exits `1`.
-- `ai-run --verify` refuses to run a model whose blob is REJECTED (exit `1`,
-  with an `ollama rm` hint). Files the WASM verifier cannot handle (over the
-  3 GiB wasm32 ceiling) are warned about and skipped — only an affirmative
-  REJECT blocks the run.
+- `ai-run --verify` is fail-closed: a REJECTED blob exits `1` with an
+  `ollama rm` hint, while a missing/unreadable blob, verifier error, or file
+  above the 3 GiB wasm32 ceiling exits `2` without running the model.
+- `--allow-unverified` is an explicit escape hatch for the no-verdict cases
+  above. It requires `--verify` and can never bypass a ModelVet REJECT.
 - Blob resolution reads the Ollama manifest store (`$OLLAMA_MODELS` or
   `~/.ollama/models`), so no Ollama API changes are needed.
 
@@ -1050,7 +1064,7 @@ llm-checker smart-recommend --use-case reasoning
 ## Development
 
 ```bash
-git clone https://github.com/Pavelevich/llm-checker.git
+git clone https://github.com/signerless/llm-checker.git
 cd llm-checker
 npm install
 node bin/enhanced_cli.js hw-detect
@@ -1089,13 +1103,13 @@ LLM Checker is licensed under **NPDL-1.0** (No Paid Distribution License).
 - Free use, modification, and redistribution are allowed.
 - Selling the software or offering it as a paid hosted/API service is not allowed without a separate commercial license.
 
-See [LICENSE](https://github.com/Pavelevich/llm-checker/blob/main/LICENSE) for full terms.
+See [LICENSE](https://github.com/signerless/llm-checker/blob/main/LICENSE) for full terms.
 
 ---
 
-[GitHub](https://github.com/Pavelevich/llm-checker) •
-[Releases](https://github.com/Pavelevich/llm-checker/releases) •
+[GitHub](https://github.com/signerless/llm-checker) •
+[Releases](https://github.com/signerless/llm-checker/releases) •
 [npm](https://www.npmjs.com/package/llm-checker) •
 [GitHub Packages](https://github.com/users/Pavelevich/packages/npm/package/llm-checker) •
-[Issues](https://github.com/Pavelevich/llm-checker/issues) •
+[Issues](https://github.com/signerless/llm-checker/issues) •
 [Discord](https://discord.gg/mnmYrA7T)

--- a/THIRD_PARTY_NOTICES
+++ b/THIRD_PARTY_NOTICES
@@ -1,0 +1,32 @@
+Third-Party Notices
+===================
+
+ModelVet
+--------
+
+LLM Checker includes a WebAssembly build derived from ModelVet, vendored at
+commit 748ac72c3c040ba097d6d3ff70fb520c776e17cb.
+
+Source: https://github.com/tetsuo-ai/modelvet
+
+MIT License
+
+Copyright (c) 2026 AgenC (tetsuo-ai)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -3,10 +3,10 @@
 
 const majorNodeVersion = Number.parseInt(process.versions.node.split('.')[0], 10);
 
-if (!Number.isFinite(majorNodeVersion) || majorNodeVersion < 16) {
+if (!Number.isFinite(majorNodeVersion) || majorNodeVersion < 18) {
     console.error(
         `[llm-checker] Unsupported Node.js version: ${process.versions.node}. ` +
-        'Please use Node.js 16 or newer.'
+        'Please use Node.js 18 or newer.'
     );
     process.exit(1);
 }

--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -816,11 +816,13 @@ function getClaudeDesktopConfigPath() {
 
 function buildClaudeMcpSetup(useNpx = false, serverName = 'llm-checker') {
     const normalizedServerName = String(serverName || 'llm-checker').trim() || 'llm-checker';
-    const runner = useNpx ? ['npx', 'llm-checker-mcp'] : ['llm-checker-mcp'];
+    const runner = useNpx
+        ? ['npx', '--yes', '--package', 'llm-checker', 'llm-checker-mcp']
+        : ['llm-checker-mcp'];
     const claudeArgs = ['mcp', 'add', normalizedServerName, '--', ...runner];
     const commandLine = ['claude', ...claudeArgs].map(quoteCliArg).join(' ');
     const desktopServerConfig = useNpx
-        ? { command: 'npx', args: ['llm-checker-mcp'] }
+        ? { command: 'npx', args: ['--yes', '--package', 'llm-checker', 'llm-checker-mcp'] }
         : { command: 'llm-checker-mcp', args: [] };
 
     return {
@@ -856,10 +858,12 @@ async function runExternalCommand(command, args) {
 const MCP_SETUP_CLIENTS = ['claude', 'codex', 'cursor', 'windsurf', 'gemini', 'kimi', 'grok', 'generic'];
 
 // The stdio server entry every client launches: the globally installed
-// `llm-checker-mcp` binary, or `npx llm-checker-mcp` with --npx.
+// `llm-checker-mcp` binary, or an explicit `npx --package llm-checker`
+// invocation with --npx. `llm-checker-mcp` is a bin exposed by the
+// `llm-checker` package, not a standalone npm package name.
 function getMcpServerEntry(useNpx = false) {
     return useNpx
-        ? { command: 'npx', args: ['llm-checker-mcp'] }
+        ? { command: 'npx', args: ['--yes', '--package', 'llm-checker', 'llm-checker-mcp'] }
         : { command: 'llm-checker-mcp', args: [] };
 }
 
@@ -3241,7 +3245,7 @@ program
     .description('Show or apply MCP setup for llm-checker (Claude Code, Codex, Cursor, Windsurf, Gemini, Kimi, Grok, or generic)')
     .option('--client <name>', `Target MCP client (${MCP_SETUP_CLIENTS.join(', ')})`, 'claude')
     .option('--name <server-name>', 'MCP server name in the client config', 'llm-checker')
-    .option('--npx', 'Use npx llm-checker-mcp instead of global llm-checker-mcp')
+    .option('--npx', 'Use npx --yes --package llm-checker llm-checker-mcp instead of a global install')
     .option('--apply', 'Apply the setup (run the client CLI or merge its config file)')
     .option('-j, --json', 'Output setup details as JSON')
     .action(async (options) => {
@@ -4989,9 +4993,14 @@ program
     )
     .option('--benchmark', 'Run a short local speed test before launching')
     .option('--reference-only', 'Show model choice and speed reference without launching Ollama')
-    .option('--verify', 'Verify the selected model blob with modelvet before running (REJECT aborts the run)')
+    .option('--verify', 'Verify the selected model blob with modelvet before running (fails closed unless ACCEPT)')
+    .option('--allow-unverified', 'Continue only when --verify cannot produce a verdict; never bypasses REJECT')
     .action(async (options) => {
         showAsciiArt('ai-run');
+        if (options.allowUnverified && !options.verify) {
+            console.error(chalk.red('Error: --allow-unverified requires --verify.'));
+            process.exit(1);
+        }
         // Check if Ollama is installed first
         await checkOllamaAndExit();
         
@@ -5088,13 +5097,11 @@ program
             // local blob BEFORE the model is ever loaded/run (also covers the
             // post-`ollama pull` case, since pull only writes these same
             // manifests/blobs). Semantics:
-            //   REJECT  -> hard stop, refuse to run, exit 1.
+            //   REJECT  -> hard stop, refuse to run, exit 1. No override.
             //   skipped -> manifest/blob missing or verifier error (e.g.
             //              >3 GiB wasm32 ceiling, wasm artifact missing):
-            //              warn and continue. Verification is an opt-in
-            //              best-effort gate; blocking normal runs because the
-            //              verifier itself cannot cover a file would break
-            //              legitimate usage. Only an affirmative REJECT blocks.
+            //              fail closed by default. --allow-unverified is the
+            //              explicit opt-in escape hatch for this state only.
             if (options.verify) {
                 const { verifyOllamaModel } = require('../src/security/ollama-blobs');
                 const verifySpinner = ora(`Verifying ${result.bestModel} blob structure with modelvet...`).start();
@@ -5115,8 +5122,20 @@ program
                     console.log(chalk.gray('  (ACCEPT is structural only — no provenance or poisoned-weights guarantee.)'));
                 } else {
                     verifySpinner.stop();
-                    console.log(chalk.yellow(`Verification skipped: ${verification.reason}`));
-                    console.log(chalk.gray('Continuing without verification (--verify is best-effort).'));
+                    const reason = verification.reason || 'modelvet did not produce a verification verdict';
+                    console.log(chalk.yellow(`Verification unavailable: ${reason}`));
+                    if (options.allowUnverified) {
+                        console.log(chalk.yellow.bold(
+                            'Continuing without verification because --allow-unverified was explicitly set.'
+                        ));
+                    } else {
+                        console.log(chalk.red.bold('Refusing to run without an ACCEPT verdict (fail-closed, exit 2).'));
+                        console.log(chalk.gray(
+                            'If you accept this risk, re-run with --verify --allow-unverified. ' +
+                            'This override never bypasses a REJECT verdict.'
+                        ));
+                        process.exit(2);
+                    }
                 }
             }
 
@@ -6032,7 +6051,7 @@ program
 
 program
     .command('verify <file>')
-    .description('Structural safety validation of a GGUF or safetensors model file (modelvet, verify-before-load)')
+    .description('ModelVet: verify GGUF or safetensors structural safety before loading')
     .option('-j, --json', 'Output as JSON')
     .action(async (file, options) => {
         const spinner = options.json ? null : ora('Verifying model file structure...').start();

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -7,7 +7,7 @@
  * and other MCP-compatible AI assistants.
  *
  * Usage:
- *   claude mcp add llm-checker -- npx llm-checker-mcp
+ *   claude mcp add llm-checker -- npx --yes --package llm-checker llm-checker-mcp
  *   # or
  *   claude mcp add llm-checker -- node node_modules/llm-checker/bin/mcp-server.mjs
  */
@@ -18,9 +18,9 @@ import { z } from "zod";
 import { execFile } from "child_process";
 import { promisify } from "util";
 import { fileURLToPath } from "url";
-import { dirname, join } from "path";
+import { dirname, join, normalize, resolve } from "path";
 import { readdir, stat } from "fs/promises";
-import { readFileSync } from "fs";
+import { readFileSync, realpathSync } from "fs";
 import { createRequire } from "module";
 import http from "http";
 import os from "os";
@@ -436,7 +436,7 @@ server.tool(
 
 server.tool(
   "verify_model",
-  "Structurally verify a local model file (GGUF or safetensors) with the modelvet WASM verifier before any model loader touches it. Returns the full verification report (format, verdict, accepted, violation, violationName, offset, detail, arenaUsed, modelvetVersion, file, sizeBytes). An 'accept' verdict is structural only: it says nothing about model behavior, provenance, or poisoned weights. Verifier/infrastructure errors are returned as { verdict: 'error', reason, code } instead of throwing.",
+  "Structurally verify a local model file (GGUF or safetensors) with the modelvet WASM verifier before any model loader touches it. Returns the full verification report (format, verdict, accepted, violation, violationName, offset, detail, arenaUsed, modelvetVersion, file, sizeBytes). An 'accept' verdict is structural only: it says nothing about model behavior, provenance, or poisoned weights. Verifier/infrastructure failures return { verdict: 'error', reason, code } with the MCP isError flag set.",
   {
     path: z.string().describe("Path to the model file (.gguf or .safetensors)"),
     format: z
@@ -478,7 +478,10 @@ server.tool(
         reason: err.message,
         code: err.code || "MODELVET_ERROR",
       };
-      return { content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] };
+      return {
+        content: [{ type: "text", text: JSON.stringify(payload, null, 2) }],
+        isError: true,
+      };
     }
   }
 );
@@ -1559,22 +1562,35 @@ async function main() {
   await server.connect(transport);
 }
 
-// Detect whether this module is the process entry point. When invoked as
-// `node bin/mcp-server.mjs`, process.argv[1] resolves to this file's path; when
-// merely imported (e.g. from a test), it points at the importer instead, so the
-// server is not started. fileURLToPath(import.meta.url) gives this file's
-// absolute path; argv[1] is the absolute path Node was launched with. We also
-// resolve argv[1] through fileURLToPath when it is a file:// URL.
-function runningAsEntry() {
-  const entry = process.argv[1];
-  if (!entry) return false;
+// Resolve a path (or file: URL) to the filesystem's canonical spelling. npm
+// installs package bins as symlinks on POSIX, so process.argv[1] can name the
+// symlink while import.meta.url names its target. A raw string comparison makes
+// a correctly installed `llm-checker-mcp` silently exit without connecting.
+function canonicalPath(pathOrUrl) {
+  if (typeof pathOrUrl !== "string" || pathOrUrl.length === 0) return null;
   try {
-    const thisPath = fileURLToPath(import.meta.url);
-    const entryPath = entry.startsWith("file://") ? fileURLToPath(entry) : entry;
-    return entryPath === thisPath;
+    const filePath = /^file:/i.test(pathOrUrl) ? fileURLToPath(pathOrUrl) : pathOrUrl;
+    const absolutePath = resolve(filePath);
+    const canonical = realpathSync.native
+      ? realpathSync.native(absolutePath)
+      : realpathSync(absolutePath);
+
+    // Windows paths are case-insensitive. realpath normally normalizes case,
+    // but folding here also handles drive-letter differences consistently.
+    return process.platform === "win32"
+      ? normalize(canonical).toLowerCase()
+      : normalize(canonical);
   } catch {
-    return false;
+    return null;
   }
+}
+
+// Detect whether this module is the process entry point without confusing an
+// npm-installed bin symlink for an importing module.
+function runningAsEntry(entry = process.argv[1], moduleUrl = import.meta.url) {
+  const entryPath = canonicalPath(entry);
+  const modulePath = canonicalPath(moduleUrl);
+  return entryPath !== null && modulePath !== null && entryPath === modulePath;
 }
 
 if (runningAsEntry()) {
@@ -1592,4 +1608,6 @@ export {
   mapHardwareJson,
   detectFrameworkMarker,
   FRAMEWORK_MARKERS,
+  canonicalPath,
+  runningAsEntry,
 };

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+3.8.1 — ModelVet attribution (2026-08-04)
+-------------------------------------------
+
+- Added prominent README credit for
+  [ModelVet](https://github.com/tetsuo-ai/modelvet) and its creator,
+  [Tetsuo AI](https://github.com/tetsuo-ai), covering the `verify`,
+  `ai-run --verify`, structural policy validation, and MCP `verify_model`
+  integration.
+
 3.8.0 — ModelVet structural validation (2026-08-04)
 -----------------------------------------------------
 

--- a/docs/reference/changelog.md
+++ b/docs/reference/changelog.md
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased — modelvet structural validation (WASM)
---------------------------------------------------
+3.8.0 — ModelVet structural validation (2026-08-04)
+-----------------------------------------------------
 
 Verify-before-load structural safety validation for GGUF and safetensors
 model files, powered by [modelvet](https://github.com/tetsuo-ai/modelvet)
@@ -17,8 +17,10 @@ dependencies, works offline on every supported platform.
 - New verification gates in the Ollama flows: `installed --verify` audits
   every installed model's blob while ranking (any REJECT exits 1), and
   `ai-run --verify` verifies the selected model's blob after pull and
-  refuses to run a REJECTED model. Files over the 3 GiB wasm32 ceiling are
-  warned about and skipped — only an affirmative REJECT blocks.
+  refuses to run a REJECTED model. `ai-run --verify` now fails closed: missing
+  blobs/manifests, files over the 3 GiB wasm32 ceiling, verifier errors, and
+  other no-verdict states exit 2. `--allow-unverified` explicitly permits
+  only those unverifiable states; it can never bypass a REJECT verdict.
 - New `structural_validation` policy rule (`enabled`, `on_unverifiable:
   warn|fail`): a REJECTED local model is a `STRUCTURAL_VALIDATION_FAILED`
   violation (blocking in enforce mode); catalog-only candidates are

--- a/docs/reference/technical-docs.md
+++ b/docs/reference/technical-docs.md
@@ -553,7 +553,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        node-version: [16, 18, 20]
+        node-version: [18, 20, 22]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.7.6",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.7.6",
+      "version": "3.8.0",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [
@@ -16,13 +16,13 @@
         "win32"
       ],
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.29.0",
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "chalk": "^4.1.2",
         "commander": "^11.1.0",
         "inquirer": "^8.2.6",
         "node-fetch": "^2.7.0",
         "ora": "^5.4.1",
-        "systeminformation": "^5.31.6",
+        "systeminformation": "^5.33.1",
         "table": "^6.8.1",
         "yaml": "^2.9.0",
         "zod": "^3.23.0"
@@ -37,7 +37,7 @@
         "jest": "^30.4.2"
       },
       "engines": {
-        "node": ">=16.0.0",
+        "node": ">=18.0.0",
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
@@ -45,13 +45,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -60,9 +60,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
-      "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -70,21 +70,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -101,14 +101,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -118,14 +118,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -145,29 +145,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -177,9 +177,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -187,9 +187,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -197,9 +197,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -207,9 +207,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -217,27 +217,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -302,13 +302,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-import-attributes": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-      "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -344,13 +344,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
-      "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
+      "integrity": "sha512-TSu8+mHCoEaaCDEZ0I3+6mvTBYR4PCxQwf2z9/r5Tbztv6NaLR3B9thGTTxX2WGuGHJqRiAbKPeGTJ5XWXVg6A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -470,13 +470,13 @@
       }
     },
     "node_modules/@babel/plugin-syntax-typescript": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
-      "integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.29.7.tgz",
+      "integrity": "sha512-ngr+82Sh0xMz25TPCZi+nC2iTzjfCdWS2ONXTp/PtSCHCgaCNBpdMqgvJ2ccdLlClVZ7sisIgB914j/JFe+RZA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.28.6"
+        "@babel/helper-plugin-utils": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -486,33 +486,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -520,14 +520,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -575,12 +575,12 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.14",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.0.tgz",
+      "integrity": "sha512-XovyyCCnBzW+zKu+z/zq8hwNs4KOR5rEMAOxo2f40Q5xoOI37IMm6MIg2COOUtUApo0i6850MTBKH2u4QLGIqg==",
       "license": "MIT",
       "engines": {
-        "node": ">=18.14.1"
+        "node": ">=20"
       },
       "peerDependencies": {
         "hono": "^4"
@@ -1026,12 +1026,12 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
       "license": "MIT",
       "dependencies": {
-        "@hono/node-server": "^1.19.9",
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
         "ajv": "^8.17.1",
         "ajv-formats": "^3.0.1",
         "content-type": "^1.0.5",
@@ -1066,41 +1066,44 @@
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.2.2.tgz",
+      "integrity": "sha512-JfB4kuJQjaoHuCTseIINHtHWeJnvgEcxjwA5t/Y00ZgaOO1Crz3fjT/p8kT28zA/Caz7oiUMn3d6H2yOVCVwuw==",
       "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=23.5.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
       "peerDependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1"
+        "@emnapi/core": "^1.7.1 || ^2.0.0-alpha.3",
+        "@emnapi/runtime": "^1.7.1 || ^2.0.0-alpha.3"
       }
     },
     "node_modules/@pkgr/core": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-      "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+      "integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.34.49",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
-      "integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1125,9 +1128,9 @@
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1208,9 +1211,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.19.41",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.41.tgz",
-      "integrity": "sha512-ECymXOukMnOoVkC2bb1Vc/w/836DXncOg5m8Xj1RH7xSHZJWNYY6Zh7EH477vcnD5egKNNfy2RpNOmuChhFPgQ==",
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -1242,9 +1245,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
-      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },
@@ -1575,9 +1578,9 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1822,9 +1825,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.32",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+      "version": "2.11.12",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.12.tgz",
+      "integrity": "sha512-r7WnVImvVCeFpf2DOXfy41aPWzeNg3H/A2X4dKmy1QL0MSyyk/e7z8ihJ3N6Nn2PsdhkVlqnEfnUE4a05P2aTA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1846,20 +1849,20 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
-      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
       "license": "MIT",
       "dependencies": {
         "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "debug": "^4.4.3",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.7.0",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
         "on-finished": "^2.4.1",
-        "qs": "^6.14.1",
-        "raw-body": "^3.0.1",
-        "type-is": "^2.0.1"
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -1869,23 +1872,36 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-      "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+      "version": "4.28.7",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+      "integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
       "dev": true,
       "funding": [
         {
@@ -1903,10 +1919,10 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
+        "baseline-browser-mapping": "^2.10.44",
+        "caniuse-lite": "^1.0.30001806",
+        "electron-to-chromium": "^1.5.393",
+        "node-releases": "^2.0.51",
         "update-browserslist-db": "^1.2.3"
       },
       "bin": {
@@ -2016,9 +2032,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001793",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -2063,9 +2079,9 @@
       }
     },
     "node_modules/chardet": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
-      "integrity": "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-2.2.0.tgz",
+      "integrity": "sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==",
       "license": "MIT"
     },
     "node_modules/ci-info": {
@@ -2212,9 +2228,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
-      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -2383,9 +2399,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.361",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+      "version": "1.5.400",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.400.tgz",
+      "integrity": "sha512-96EWDNjM59SYflgeV5Ylsf4EMiq1a25YjCnJH7cxn/AF2H3pILRweaUnoLax0yKHWdpOzY6JKEu45e8irqZIHA==",
       "dev": true,
       "license": "ISC"
     },
@@ -2446,9 +2462,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2518,9 +2534,9 @@
       }
     },
     "node_modules/eventsource-parser": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
-      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -2622,11 +2638,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.5.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
-      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
       "license": "MIT",
       "dependencies": {
+        "debug": "^4.4.3",
         "ip-address": "^10.2.0"
       },
       "engines": {
@@ -2653,9 +2670,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -2909,9 +2926,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2921,9 +2938,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.22",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.22.tgz",
-      "integrity": "sha512-7fvVPbB92zNRsQke+uiRGwtTuef0tB2Dg4hWxYfFNvkQhIltWoyi0ONReM5LWA+jJWS3nfT5lTq+qbsIpX0IQw==",
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.0.tgz",
+      "integrity": "sha512-jhunvfHWxd7J5EFfSgH4xsYJzSe/lfqbUCxiyyeaQasUsXeEHXtzVid+7EOGByc5JnFa23SSFL3Y2RV/z1T+eQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -2967,9 +2984,9 @@
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
-      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
       "license": "MIT",
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3.0.0"
@@ -3065,9 +3082,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -3182,9 +3199,9 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3717,9 +3734,9 @@
       }
     },
     "node_modules/jest-snapshot/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -3832,9 +3849,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
-      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"
@@ -3848,9 +3865,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3991,9 +4008,9 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -4023,12 +4040,16 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/merge-descriptors": {
@@ -4085,13 +4106,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4182,9 +4203,9 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.46",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+      "version": "2.0.52",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.52.tgz",
+      "integrity": "sha512-MRlTqhAfoMx/4mhEbPo3Hi02g9LJZaJkka69V6h67Cb1gjrAG0jsTE4CZX1eptNx+VCAwJmfpnDIF4P0Nh1A7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4414,9 +4435,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.5.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
-      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4441,9 +4462,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4545,12 +4566,13 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -4560,12 +4582,16 @@
       }
     },
     "node_modules/range-parser": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
-      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/raw-body": {
@@ -4593,9 +4619,9 @@
     },
     "node_modules/react-is-19": {
       "name": "react-is",
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.6.tgz",
-      "integrity": "sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -4811,14 +4837,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -4830,13 +4856,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -5077,13 +5103,13 @@
       }
     },
     "node_modules/synckit": {
-      "version": "0.11.12",
-      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-      "integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+      "version": "0.11.13",
+      "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+      "integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@pkgr/core": "^0.2.9"
+        "@pkgr/core": "^0.3.6"
       },
       "engines": {
         "node": "^14.18.0 || >=16.0.0"
@@ -5093,9 +5119,9 @@
       }
     },
     "node_modules/systeminformation": {
-      "version": "5.31.6",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.31.6.tgz",
-      "integrity": "sha512-Uv2b2uGGM6ns+26czgW2cYRabYdnswM0ddSOOlryHOaelzsmDSet1iM/NT7VOYxW8x/BW+HkY+b1Ve2pLTSGSA==",
+      "version": "5.33.1",
+      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.33.1.tgz",
+      "integrity": "sha512-DEN6ICHk3Tk0Uf/hrAHh7xlt7iL5CJFBtPZinA0H62DrGG/KPKqq/Nzj6lCXPS4Ay/sf/14zNnk9LpqKzBIc+w==",
       "license": "MIT",
       "os": [
         "darwin",
@@ -5111,7 +5137,7 @@
         "systeminformation": "lib/cli.js"
       },
       "engines": {
-        "node": ">=8.0.0"
+        "node": ">=10.0.0"
       },
       "funding": {
         "type": "Buy me a coffee",
@@ -5206,17 +5232,34 @@
       }
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
+        "content-type": "^2.0.0",
         "media-typer": "^1.1.0",
         "mime-types": "^3.0.0"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/undici-types": {
@@ -5464,9 +5507,9 @@
       }
     },
     "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "version": "17.7.3",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+      "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5515,12 +5558,12 @@
       }
     },
     "node_modules/zod-to-json-schema": {
-      "version": "3.25.1",
-      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
-      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
       "license": "ISC",
       "peerDependencies": {
-        "zod": "^3.25 || ^4"
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "llm-checker",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "llm-checker",
-      "version": "3.8.0",
+      "version": "3.8.1",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE",
       "os": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.8.0",
+  "version": "3.8.1",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-checker",
-  "version": "3.7.6",
+  "version": "3.8.0",
   "description": "Intelligent CLI tool with AI-powered model selection that analyzes your hardware and recommends optimal LLM models for your system",
   "bin": {
     "llm-checker": "bin/cli.js",
@@ -10,6 +10,7 @@
   "main": "src/index.js",
   "scripts": {
     "test": "node tests/run-all-tests.js",
+    "prepublishOnly": "npm test && npm audit --omit=dev",
     "test:roadmap": "node tests/roadmap-tools.test.js",
     "test:gpu": "node tests/amd-gpu-detection.test.js",
     "test:platform": "node tests/hardware-simulation-tests.js",
@@ -52,13 +53,13 @@
     "postinstall": "echo 'LLM Checker installed. Run: llm-checker hw-detect'"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.29.0",
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "chalk": "^4.1.2",
     "commander": "^11.1.0",
     "inquirer": "^8.2.6",
     "node-fetch": "^2.7.0",
     "ora": "^5.4.1",
-    "systeminformation": "^5.31.6",
+    "systeminformation": "^5.33.1",
     "table": "^6.8.1",
     "yaml": "^2.9.0",
     "zod": "^3.23.0"
@@ -68,7 +69,7 @@
   },
   "overrides": {
     "ajv": "^8.18.0",
-    "hono": "^4.11.10",
+    "hono": "^4.13.0",
     "glob": "^13.0.0",
     "minimatch": "^10.2.2",
     "test-exclude": "^7.0.1"
@@ -107,14 +108,14 @@
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Pavelevich/llm-checker.git"
+    "url": "git+https://github.com/signerless/llm-checker.git"
   },
-  "homepage": "https://github.com/Pavelevich/llm-checker#readme",
+  "homepage": "https://github.com/signerless/llm-checker#readme",
   "bugs": {
-    "url": "https://github.com/Pavelevich/llm-checker/issues"
+    "url": "https://github.com/signerless/llm-checker/issues"
   },
   "engines": {
-    "node": ">=16.0.0",
+    "node": ">=18.0.0",
     "npm": ">=8.0.0"
   },
   "os": [
@@ -129,6 +130,7 @@
     "src/",
     "analyzer/",
     "README.md",
-    "LICENSE"
+    "LICENSE",
+    "THIRD_PARTY_NOTICES"
   ]
 }

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -239,7 +239,7 @@ main() {
     echo "  - Run benchmarks: node scripts/benchmark.js"
     echo "  - View logs: tail -f ~/.llm-checker/logs/llm-checker.log"
     echo ""
-    print_status "Documentation: https://github.com/Pavelevich/llm-checker"
+    print_status "Documentation: https://github.com/signerless/llm-checker"
 }
 
 # Run main function

--- a/src/policy/audit-reporter.js
+++ b/src/policy/audit-reporter.js
@@ -426,7 +426,7 @@ function reportToSarif(report) {
                     driver: {
                         name: 'llm-checker-policy',
                         version: '1.0.0',
-                        informationUri: 'https://github.com/Pavelevich/llm-checker',
+                        informationUri: 'https://github.com/signerless/llm-checker',
                         rules: Array.from(rulesMap.values())
                     }
                 },

--- a/src/ui/banner-profesional-v2.txt
+++ b/src/ui/banner-profesional-v2.txt
@@ -31,6 +31,6 @@
  | Install: npm install -g llm-checker                                                                                                              |
  | Run: llm-checker recommend                                                                                                                        |
  |                                                                                                                                                  |
- | github.com/Pavelevich/llm-checker  |  npmjs.com/package/llm-checker                                                                              |
+ | github.com/signerless/llm-checker   |  npmjs.com/package/llm-checker                                                                              |
  |                                                                                                                                                  |
  +--------------------------------------------------------------------------------------------------------------------------------------------------+

--- a/src/ui/cli-theme.js
+++ b/src/ui/cli-theme.js
@@ -482,7 +482,7 @@ function drawTextBanner(lines, options = {}) {
         ) {
             inner = chalk.hex(palette.subtitle)(fittedContent);
         } else if (
-            fittedContent.includes('github.com/Pavelevich/llm-checker') ||
+            fittedContent.includes('github.com/signerless/llm-checker') ||
             fittedContent.includes('npmjs.com/package/llm-checker')
         ) {
             inner = chalk.hex(palette.link)(fittedContent);

--- a/src/ui/interactive-panel.js
+++ b/src/ui/interactive-panel.js
@@ -44,6 +44,7 @@ function getReservedRows(compact = false) {
 
 const PRIMARY_COMMAND_PRIORITY = [
     'check',
+    'verify',
     'help',
     'mcp-setup',
     'recommend',
@@ -58,6 +59,14 @@ const PRIMARY_COMMAND_PRIORITY = [
 ];
 
 const REQUIRED_ARG_PROMPTS = {
+    verify: [
+        {
+            name: 'file',
+            message: 'Model file for `verify` (GGUF or safetensors):',
+            validate: (value) =>
+                value && value.trim() ? true : 'Provide a GGUF or safetensors model file path'
+        }
+    ],
     search: [
         {
             name: 'query',
@@ -66,6 +75,21 @@ const REQUIRED_ARG_PROMPTS = {
         }
     ]
 };
+
+function getRequiredArgPrompts(commandMeta) {
+    return REQUIRED_ARG_PROMPTS[commandMeta.name] || [];
+}
+
+function buildRequiredArgArgs(requiredArgPrompts, answers) {
+    const args = [];
+
+    for (const requiredPrompt of requiredArgPrompts) {
+        const value = String(answers?.[requiredPrompt.name] || '').trim();
+        if (value) args.push(value);
+    }
+
+    return args;
+}
 
 function truncateText(text, maxLength) {
     const value = String(text || '');
@@ -421,7 +445,7 @@ function shouldEnableBannerPulse({
 
 async function collectCommandArgs(commandMeta) {
     const prompts = [];
-    const requiredPrompts = REQUIRED_ARG_PROMPTS[commandMeta.name] || [];
+    const requiredPrompts = getRequiredArgPrompts(commandMeta);
     const requiredOptionPrompts = getRequiredOptionPrompts(commandMeta);
 
     for (const requiredPrompt of requiredPrompts) {
@@ -467,12 +491,7 @@ async function collectCommandArgs(commandMeta) {
     }
 
     const answers = await inquirer.prompt(prompts);
-    const args = [];
-
-    for (const requiredPrompt of requiredPrompts) {
-        const value = String(answers[requiredPrompt.name] || '').trim();
-        if (value) args.push(value);
-    }
+    const args = buildRequiredArgArgs(requiredPrompts, answers);
 
     args.push(...buildRequiredOptionArgs(requiredOptionPrompts, answers));
 
@@ -716,6 +735,8 @@ module.exports = {
     launchInteractivePanel,
     __private: {
         tokenizeArgString,
+        getRequiredArgPrompts,
+        buildRequiredArgArgs,
         getRequiredOptionPrompts,
         buildRequiredOptionArgs,
         normalizeVariadicValue,

--- a/tests/banner-canonical.test.js
+++ b/tests/banner-canonical.test.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const BANNER_PATH = path.resolve(__dirname, '..', 'src', 'ui', 'banner-profesional-v2.txt');
-const CANONICAL_BANNER_SHA256 = 'ddbc9788510a1577b6b584b46e4eb60409e46f8708305e6cbd6ec61e847f87f3';
+const CANONICAL_BANNER_SHA256 = '28acd9ad25fe0c6f93f28a199fa3e4d0e74b5f03f27add3f7ead765050918237';
 
 function run() {
     const raw = fs.readFileSync(BANNER_PATH, 'utf8');

--- a/tests/calibration-e2e-integration.test.js
+++ b/tests/calibration-e2e-integration.test.js
@@ -144,6 +144,7 @@ function run() {
                 policyPath,
                 '--category',
                 'coding',
+                '--no-registry',
                 '--no-verbose'
             ],
             tempDir,

--- a/tests/cli-interactive-panel.test.js
+++ b/tests/cli-interactive-panel.test.js
@@ -3,6 +3,8 @@ const { Command } = require('commander');
 const {
     __private: {
         tokenizeArgString,
+        getRequiredArgPrompts,
+        buildRequiredArgArgs,
         getRequiredOptionPrompts,
         buildRequiredOptionArgs,
         normalizeVariadicValue,
@@ -70,6 +72,35 @@ function run() {
         ['qwen2.5-coder:7b', 'llama3.2:3b', 'mistral:7b']
     );
 
+    const verifyArgPrompts = getRequiredArgPrompts({ name: 'verify' });
+    assert.deepStrictEqual(
+        verifyArgPrompts.map(({ name, message }) => ({ name, message })),
+        [
+            {
+                name: 'file',
+                message: 'Model file for `verify` (GGUF or safetensors):'
+            }
+        ],
+        'verify should declare its required model file prompt'
+    );
+    assert.strictEqual(
+        verifyArgPrompts[0].validate('   '),
+        'Provide a GGUF or safetensors model file path',
+        'verify should reject an empty model file path'
+    );
+    assert.strictEqual(
+        verifyArgPrompts[0].validate('./models/demo.gguf'),
+        true,
+        'verify should accept a model file path'
+    );
+    assert.deepStrictEqual(
+        buildRequiredArgArgs(verifyArgPrompts, {
+            file: '  ./video fixtures/accepted model.gguf  '
+        }),
+        ['./video fixtures/accepted model.gguf'],
+        'verify should pass the prompted file path as one positional CLI argument'
+    );
+
     const calibrateCommand = new Command('calibrate');
     calibrateCommand.requiredOption('--suite <file>', 'Prompt suite path');
     calibrateCommand.requiredOption('--models <identifiers...>', 'Models');
@@ -107,6 +138,7 @@ function run() {
         commands: [
             createMockCommand('recommend', 'Recommend models'),
             createMockCommand('check', 'Check compatibility'),
+            createMockCommand('verify', 'Verify model structure with modelvet'),
             createMockCommand('help', 'Show all commands and how to use them'),
             createMockCommand('search', 'Search models'),
             createMockCommand('sync', 'Sync database')
@@ -118,8 +150,9 @@ function run() {
 
     const primary = buildPrimaryCommands(catalog);
     assert.strictEqual(primary[0].name, 'check', 'primary ordering should prioritize check');
-    assert.strictEqual(primary[1].name, 'help', 'primary ordering should prioritize help');
-    assert.strictEqual(primary[2].name, 'recommend', 'primary ordering should prioritize recommend');
+    assert.strictEqual(primary[1].name, 'verify', 'primary ordering should place verify after check');
+    assert.strictEqual(primary[2].name, 'help', 'primary ordering should prioritize help');
+    assert.strictEqual(primary[3].name, 'recommend', 'primary ordering should prioritize recommend');
 
     const stateClosed = { paletteOpen: false, query: '', selected: 0 };
     const visibleClosed = getVisibleCommands(stateClosed, catalog, primary);

--- a/tests/mcp-multiclient.test.mjs
+++ b/tests/mcp-multiclient.test.mjs
@@ -15,11 +15,13 @@ import { fileURLToPath } from "url";
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
 import { server } from "../bin/mcp-server.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const BIN_PATH = path.resolve(__dirname, "..", "bin", "enhanced_cli.js");
+const MCP_SERVER_PATH = path.resolve(__dirname, "..", "bin", "mcp-server.mjs");
 
 function runCli(args, home) {
   return spawnSync(process.execPath, [BIN_PATH, ...args], {
@@ -93,20 +95,62 @@ async function testVerifyModelTool(tempDir) {
     fs.writeFileSync(badPath, buildGguf({ version: 99 }));
     const badResult = await client.callTool({ name: "verify_model", arguments: { path: badPath } });
     const bad = toolResultJson(badResult);
+    assert.notStrictEqual(badResult.isError, true, "a structural rejection is a completed verification result");
     assert.strictEqual(bad.accepted, false, "version-99 GGUF must be rejected");
     assert.strictEqual(bad.verdict, "reject");
     assert.strictEqual(bad.violationName, "VERSION_UNSUPPORTED");
 
-    // Missing path -> structured error payload, not a thrown/protocol error.
+    // Missing path -> structured payload marked as an MCP tool error. The
+    // client still receives machine-readable ModelVet details.
     const missingResult = await client.callTool({
       name: "verify_model",
       arguments: { path: path.join(tempDir, "missing.gguf") },
     });
     const missing = toolResultJson(missingResult);
+    assert.strictEqual(missingResult.isError, true, "verifier infrastructure failures must set MCP isError");
     assert.strictEqual(missing.verdict, "error", "missing file must yield verdict 'error'");
     assert.ok(typeof missing.reason === "string" && missing.reason.length > 0, "error payload must carry a reason");
     assert.ok(typeof missing.code === "string" && missing.code.length > 0, "error payload must carry a code");
   });
+}
+
+async function testStdioHandshakeThroughSymlink(tempDir) {
+  const shimDir = path.join(tempDir, "node_modules", ".bin");
+  const shimPath = path.join(shimDir, "llm-checker-mcp");
+  fs.mkdirSync(shimDir, { recursive: true });
+
+  // npm creates package-bin symlinks on POSIX. Launching Node with that link
+  // makes argv[1] differ from import.meta.url even though both identify the
+  // same file; this is the exact installed-package regression being covered.
+  fs.symlinkSync(MCP_SERVER_PATH, shimPath, "file");
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [shimPath],
+    stderr: "pipe",
+  });
+  const client = new Client({ name: "mcp-symlink-handshake-test", version: "0.0.0" });
+  let timeout;
+
+  try {
+    await Promise.race([
+      client.connect(transport),
+      new Promise((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error("timed out waiting for MCP initialize through the npm-style symlink")),
+          10_000
+        );
+      }),
+    ]);
+
+    // connect() completes the MCP initialize/initialized handshake. Listing
+    // tools proves the child stayed up and is serving protocol messages.
+    const { tools } = await client.listTools();
+    assert.ok(tools.some((tool) => tool.name === "verify_model"), "symlink-launched server must expose verify_model");
+  } finally {
+    clearTimeout(timeout);
+    await client.close().catch(() => {});
+  }
 }
 
 function testMcpSetupClients(home) {
@@ -170,12 +214,40 @@ function testMcpSetupClients(home) {
   assert.strictEqual(generic.apply, null);
   assert.strictEqual(generic.snippet.mcpServers["llm-checker"].command, "llm-checker-mcp");
 
-  // --npx switches the launch command for every client.
-  const npxCursor = parseJsonRun(["mcp-setup", "--client", "cursor", "--npx", "--json"]);
-  assert.deepStrictEqual(npxCursor.snippet.mcpServers["llm-checker"], { command: "npx", args: ["llm-checker-mcp"] });
-  const npxCodex = parseJsonRun(["mcp-setup", "--client", "codex", "--npx", "--json"]);
-  assert.ok(npxCodex.snippet.includes('command = "npx"'), `codex npx snippet: ${npxCodex.snippet}`);
-  assert.ok(npxCodex.snippet.includes('args = ["llm-checker-mcp"]'), `codex npx snippet: ${npxCodex.snippet}`);
+  // --npx must select the npm package explicitly. `llm-checker-mcp` is a bin
+  // exposed by `llm-checker`, not a standalone package name.
+  const npxArgs = ["--yes", "--package", "llm-checker", "llm-checker-mcp"];
+  const npxClaude = parseJsonRun(["mcp-setup", "--client", "claude", "--npx", "--json"]);
+  assert.deepStrictEqual(
+    npxClaude.claudeDesktop.snippet.mcpServers["llm-checker"],
+    { command: "npx", args: npxArgs }
+  );
+  assert.deepStrictEqual(
+    npxClaude.recommended.args,
+    ["mcp", "add", "llm-checker", "--", "npx", ...npxArgs]
+  );
+
+  for (const clientName of ["cursor", "windsurf", "gemini", "kimi", "generic"]) {
+    const setup = parseJsonRun(["mcp-setup", "--client", clientName, "--npx", "--json"]);
+    assert.deepStrictEqual(
+      setup.snippet.mcpServers["llm-checker"],
+      { command: "npx", args: npxArgs },
+      `${clientName} must use the package-qualified npx command`
+    );
+  }
+
+  for (const clientName of ["codex", "grok"]) {
+    const setup = parseJsonRun(["mcp-setup", "--client", clientName, "--npx", "--json"]);
+    assert.ok(setup.snippet.includes('command = "npx"'), `${clientName} npx snippet: ${setup.snippet}`);
+    assert.ok(
+      setup.snippet.includes('args = ["--yes", "--package", "llm-checker", "llm-checker-mcp"]'),
+      `${clientName} npx snippet: ${setup.snippet}`
+    );
+    assert.ok(
+      setup.commandLine.includes('npx --yes --package llm-checker llm-checker-mcp'),
+      `${clientName} npx commandLine: ${setup.commandLine}`
+    );
+  }
 
   // Unknown client -> non-zero exit, no silent fallback.
   const bad = runCli(["mcp-setup", "--client", "nope", "--json"], home);
@@ -277,6 +349,7 @@ async function run() {
   const cliHome = fs.mkdtempSync(path.join(os.tmpdir(), "llm-checker-mcp-home-"));
   try {
     await testVerifyModelTool(tempDir);
+    await testStdioHandshakeThroughSymlink(tempDir);
     testMcpSetupClients(cliHome);
     testMcpSetupApplyMerges();
     console.log("mcp-multiclient tests: OK");

--- a/tests/ollama-client-speed-metrics.test.js
+++ b/tests/ollama-client-speed-metrics.test.js
@@ -176,23 +176,29 @@ fetch('${resolvedBaseURL}/api/version', { headers: { 'Content-Type': 'applicatio
     assert(Number.isFinite(probeTPS) && probeTPS > 0, `Expected positive real probe TPS, got ${probeTPS}`);
 
     const aiCheckSelector = new AICheckSelector();
-    const aiResult = await aiCheckSelector.callOllamaEvaluator(probeModel.name, {
-        hardware: { category: 'general' },
-        candidates: [
-            {
-                name: probeModel.name,
-                paramsB: probeModelSizeB,
-                quant: String(probeModel.quantization || 'Q4'),
-                requiredGB: Math.max(1, Number(probeModel.fileSizeGB) || 1),
-                budgetGB: 24,
-                installed: true
-            }
-        ]
-    });
-    assert.strictEqual(aiResult.winner, probeModel.name, `Expected evaluator winner to be ${probeModel.name}`);
-    assert(Array.isArray(aiResult.ranking), 'Expected ranking array in evaluator response');
-    assert.strictEqual(aiResult.ranking.length, 1, 'Expected single ranking entry with one candidate');
-    assert.strictEqual(aiResult.ranking[0].name, probeModel.name, 'Expected ranking to include selected probe model');
+    const hardware = await deterministicSelector.getHardware();
+    const evaluatorModel = await aiCheckSelector.pickEvaluatorModel(hardware);
+    if (evaluatorModel) {
+        const aiResult = await aiCheckSelector.callOllamaEvaluator(evaluatorModel, {
+            hardware: { category: 'general' },
+            candidates: [
+                {
+                    name: probeModel.name,
+                    paramsB: probeModelSizeB,
+                    quant: String(probeModel.quantization || 'Q4'),
+                    requiredGB: Math.max(1, Number(probeModel.fileSizeGB) || 1),
+                    budgetGB: 24,
+                    installed: true
+                }
+            ]
+        });
+        assert.strictEqual(aiResult.winner, probeModel.name, `Expected evaluator winner to be ${probeModel.name}`);
+        assert(Array.isArray(aiResult.ranking), 'Expected ranking array in evaluator response');
+        assert.strictEqual(aiResult.ranking.length, 1, 'Expected single ranking entry with one candidate');
+        assert.strictEqual(aiResult.ranking[0].name, probeModel.name, 'Expected ranking to include selected probe model');
+    } else {
+        console.log('ollama-client-speed-metrics.test.js: evaluator assertions SKIPPED (no suitable local evaluator installed)');
+    }
 
     const planResult = runCli(['ollama-plan', '--json']);
     assert.strictEqual(

--- a/tests/ui-cli-smoke.test.js
+++ b/tests/ui-cli-smoke.test.js
@@ -96,6 +96,14 @@ function run() {
         stripAnsi(aiRunHelp.stdout).includes('--calibrated [file]'),
         'ai-run help should expose calibrated routing option'
     );
+    assert.ok(
+        stripAnsi(aiRunHelp.stdout).includes('--verify'),
+        'ai-run help should expose strict model verification'
+    );
+    assert.ok(
+        stripAnsi(aiRunHelp.stdout).includes('--allow-unverified'),
+        'ai-run help should expose the explicit no-verdict override'
+    );
 
     const aiCheckModelsSpacedHelp = runWrapperCli([
         'ai-check',

--- a/tests/verify-gates.test.js
+++ b/tests/verify-gates.test.js
@@ -23,6 +23,8 @@ const OLLAMA_ROOT = path.join(TEST_HOME, '.ollama', 'models');
 const DIGEST_OK = 'aa'.repeat(32);
 const DIGEST_BAD = 'bb'.repeat(32);
 const DIGEST_GONE = 'cc'.repeat(32);
+const DIGEST_HUGE = 'ee'.repeat(32);
+const TOO_LARGE_BYTES = (3 * 1024 * 1024 * 1024) + 1;
 
 function buildGguf({ version = 3 } = {}) {
     const buf = Buffer.alloc(24);
@@ -33,14 +35,14 @@ function buildGguf({ version = 3 } = {}) {
     return buf;
 }
 
-function writeManifest(name, tag, digest) {
+function writeManifest(name, tag, digest, size = 24) {
     const manifestDir = path.join(OLLAMA_ROOT, 'manifests', 'registry.ollama.ai', 'library', name);
     fs.mkdirSync(manifestDir, { recursive: true });
     const manifest = {
         schemaVersion: 2,
         mediaType: 'application/vnd.docker.distribution.manifest.v2+json',
         layers: [
-            { mediaType: 'application/vnd.ollama.image.model', digest: `sha256:${digest}`, size: 24 },
+            { mediaType: 'application/vnd.ollama.image.model', digest: `sha256:${digest}`, size },
             { mediaType: 'application/vnd.ollama.image.license', digest: `sha256:${'dd'.repeat(32)}`, size: 10 }
         ]
     };
@@ -53,6 +55,18 @@ function writeBlob(digest, contents) {
     fs.writeFileSync(path.join(blobDir, `sha256-${digest}`), contents);
 }
 
+function writeSparseBlob(digest, size) {
+    const blobDir = path.join(OLLAMA_ROOT, 'blobs');
+    fs.mkdirSync(blobDir, { recursive: true });
+    const blobPath = path.join(blobDir, `sha256-${digest}`);
+    const fd = fs.openSync(blobPath, 'w');
+    try {
+        fs.ftruncateSync(fd, size);
+    } finally {
+        fs.closeSync(fd);
+    }
+}
+
 function buildFakeOllamaTree() {
     writeManifest('tinyok', 'latest', DIGEST_OK);
     writeBlob(DIGEST_OK, buildGguf({ version: 3 }));
@@ -60,6 +74,10 @@ function buildFakeOllamaTree() {
     writeBlob(DIGEST_BAD, buildGguf({ version: 99 }));
     // Manifest exists but the blob was never written (partial install).
     writeManifest('tinygone', 'latest', DIGEST_GONE);
+    // Sparse file exercises the verifier's 3 GiB wasm32 guard without using
+    // 3 GiB of physical disk space or reading the contents into memory.
+    writeManifest('tinyhuge', 'latest', DIGEST_HUGE, TOO_LARGE_BYTES);
+    writeSparseBlob(DIGEST_HUGE, TOO_LARGE_BYTES);
 }
 
 // Pre-seed the Ollama registry scraper cache so checker.analyze() (called by
@@ -86,7 +104,8 @@ const http = require('http');
 const models = [
     { name: 'tinyok:latest', size: 24, details: { family: 'tinyok', parameter_size: '1B', quantization_level: 'Q4_0', format: 'gguf' } },
     { name: 'tinybad:latest', size: 24, details: { family: 'tinybad', parameter_size: '1B', quantization_level: 'Q4_0', format: 'gguf' } },
-    { name: 'tinygone:latest', size: 24, details: { family: 'tinygone', parameter_size: '1B', quantization_level: 'Q4_0', format: 'gguf' } }
+    { name: 'tinygone:latest', size: 24, details: { family: 'tinygone', parameter_size: '1B', quantization_level: 'Q4_0', format: 'gguf' } },
+    { name: 'tinyhuge:latest', size: ${TOO_LARGE_BYTES}, details: { family: 'tinyhuge', parameter_size: '7B', quantization_level: 'Q4_0', format: 'gguf' } }
 ];
 const server = http.createServer((req, res) => {
     if (req.url === '/api/version') {
@@ -187,6 +206,11 @@ async function run() {
 
             const skipped = await verifyOllamaModel('tinygone:latest');
             assert.strictEqual(skipped.status, 'skipped');
+
+            const tooLarge = await verifyOllamaModel('tinyhuge:latest');
+            assert.strictEqual(tooLarge.status, 'skipped');
+            assert.strictEqual(tooLarge.code, 'MODELVET_FILE_TOO_LARGE');
+            assert.ok(tooLarge.reason.includes('limited to 3 GiB'), tooLarge.reason);
         } finally {
             delete process.env.OLLAMA_MODELS;
         }
@@ -197,7 +221,7 @@ async function run() {
         assert.strictEqual(jsonResult.status, 1,
             `rejected model should make installed --verify exit 1; stderr: ${jsonResult.stderr}`);
         const payload = JSON.parse(jsonResult.stdout);
-        assert.strictEqual(payload.length, 3, 'expected 3 installed models in JSON output');
+        assert.strictEqual(payload.length, 4, 'expected 4 installed models in JSON output');
         const byName = Object.fromEntries(payload.map((m) => [m.name, m]));
 
         assert.strictEqual(byName['tinyok:latest'].verification.status, 'verified');
@@ -208,6 +232,9 @@ async function run() {
 
         assert.strictEqual(byName['tinygone:latest'].verification.status, 'skipped');
         assert.ok(byName['tinygone:latest'].verification.reason.length > 0);
+
+        assert.strictEqual(byName['tinyhuge:latest'].verification.status, 'skipped');
+        assert.strictEqual(byName['tinyhuge:latest'].verification.code, 'MODELVET_FILE_TOO_LARGE');
 
         // --- CLI: installed --json without --verify stays unchanged ---
         const plainResult = runCli(['installed', '--json'], cliEnv);
@@ -230,6 +257,15 @@ async function run() {
             PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}`
         };
 
+        const invalidOverride = runCli(['ai-run', '--allow-unverified', '--reference-only'], aiEnv);
+        assert.strictEqual(invalidOverride.status, 1, '--allow-unverified without --verify must be rejected');
+        assert.ok(
+            stripAnsi(`${invalidOverride.stdout}\n${invalidOverride.stderr}`).includes(
+                '--allow-unverified requires --verify'
+            ),
+            'invalid override use should explain the required verification flag'
+        );
+
         const aiReject = runCli(['ai-run', '-m', 'tinybad:latest', '--verify', '--reference-only'], aiEnv);
         assert.strictEqual(aiReject.status, 1,
             `ai-run must refuse to run a REJECTED model; stdout: ${aiReject.stdout}\nstderr: ${aiReject.stderr}`);
@@ -239,6 +275,15 @@ async function run() {
         assert.ok(aiRejectOut.includes('VERSION_UNSUPPORTED'), 'ai-run should print the violation name');
         assert.ok(aiRejectOut.includes('Refusing to run'), 'ai-run should explain the refusal');
 
+        const aiRejectOverride = runCli([
+            'ai-run', '-m', 'tinybad:latest', '--verify', '--allow-unverified', '--reference-only'
+        ], aiEnv);
+        assert.strictEqual(aiRejectOverride.status, 1,
+            `--allow-unverified must never bypass REJECT; stdout: ${aiRejectOverride.stdout}\nstderr: ${aiRejectOverride.stderr}`);
+        const aiRejectOverrideOut = stripAnsi(`${aiRejectOverride.stdout}\n${aiRejectOverride.stderr}`);
+        assert.ok(aiRejectOverrideOut.includes('REJECTED'), 'override attempt should still report REJECT');
+        assert.ok(aiRejectOverrideOut.includes('Refusing to run'), 'override attempt should still refuse to run');
+
         const aiAccept = runCli(['ai-run', '-m', 'tinyok:latest', '--verify', '--reference-only'], aiEnv);
         assert.strictEqual(aiAccept.status, 0,
             `ai-run should continue on ACCEPT; stdout: ${aiAccept.stdout}\nstderr: ${aiAccept.stderr}`);
@@ -246,11 +291,29 @@ async function run() {
         assert.ok(aiAcceptOut.includes('ACCEPT'), 'ai-run should report the ACCEPT verdict');
 
         const aiSkip = runCli(['ai-run', '-m', 'tinygone:latest', '--verify', '--reference-only'], aiEnv);
-        assert.strictEqual(aiSkip.status, 0,
-            `ai-run should warn-and-continue when verification is skipped; stdout: ${aiSkip.stdout}\nstderr: ${aiSkip.stderr}`);
+        assert.strictEqual(aiSkip.status, 2,
+            `ai-run must fail closed when verification is unavailable; stdout: ${aiSkip.stdout}\nstderr: ${aiSkip.stderr}`);
         const aiSkipOut = stripAnsi(`${aiSkip.stdout}\n${aiSkip.stderr}`);
-        assert.ok(aiSkipOut.includes('Verification skipped'),
-            'ai-run should warn when verification is skipped');
+        assert.ok(aiSkipOut.includes('Verification unavailable'),
+            'ai-run should explain that verification is unavailable');
+        assert.ok(aiSkipOut.includes('fail-closed'),
+            'ai-run should explain its fail-closed default');
+
+        const aiHuge = runCli(['ai-run', '-m', 'tinyhuge:latest', '--verify', '--reference-only'], aiEnv);
+        assert.strictEqual(aiHuge.status, 2,
+            `ai-run must fail closed above the 3 GiB WASM limit; stdout: ${aiHuge.stdout}\nstderr: ${aiHuge.stderr}`);
+        const aiHugeOut = stripAnsi(`${aiHuge.stdout}\n${aiHuge.stderr}`);
+        assert.ok(aiHugeOut.includes('limited to 3 GiB'), '3 GiB failure should explain the WASM limit');
+        assert.ok(aiHugeOut.includes('--allow-unverified'), 'failure should name the explicit override');
+
+        const aiHugeOverride = runCli([
+            'ai-run', '-m', 'tinyhuge:latest', '--verify', '--allow-unverified', '--reference-only'
+        ], aiEnv);
+        assert.strictEqual(aiHugeOverride.status, 0,
+            `explicit override should continue on an unverifiable model; stdout: ${aiHugeOverride.stdout}\nstderr: ${aiHugeOverride.stderr}`);
+        const aiHugeOverrideOut = stripAnsi(`${aiHugeOverride.stdout}\n${aiHugeOverride.stderr}`);
+        assert.ok(aiHugeOverrideOut.includes('Continuing without verification'),
+            'override continuation should be explicit in output');
 
         console.log('verify-gates.test.js: OK');
     } finally {


### PR DESCRIPTION
## What changed

- hardens the ModelVet structural-verification release across the CLI, Ollama verification gates, policies, and the MCP `verify_model` tool
- makes `ai-run --verify` fail closed and adds the explicit `--allow-unverified` override
- fixes the packaged MCP executable and the documented `npx` launch command
- adds Node 18/20/22 CI coverage, publish-time tests, dependency cleanup, and MIT third-party notices
- prominently credits [ModelVet](https://github.com/tetsuo-ai/modelvet) and [Tetsuo AI](https://github.com/tetsuo-ai) in the README
- prepares the attribution/documentation patch as version 3.8.1

## Why

PR #110 landed the base ModelVet integration, but release validation found npm-distribution blockers in the MCP binary path and launch command, plus verification behavior that could continue after structural checks failed. The public package also needed clear, durable attribution to the upstream ModelVet project and its creator.

Version 3.8.0 has already been published from the validated release commit. This PR synchronizes those release fixes back to GitHub and prepares 3.8.1 so npm can display the requested Tetsuo AI credit.

## Impact

Existing recommendation and compatibility commands remain unchanged. Verification gates are safer by default, MCP clients can launch the published binary correctly, and the npm README will visibly attribute the ModelVet feature after 3.8.1 is published.

## Validation

- `npm test` — 53/53 passing
- `npm audit --omit=dev` — 0 vulnerabilities
- `npm pack --dry-run --json` — 3.8.1 tarball contains README and THIRD_PARTY_NOTICES
- installed-tarball CLI, MCP handshake, and Grok MCP flow validated against the release code
