### PR TITLE
fix(gpu-plan): deduplicate cross-backend GPU inventory

### DIFF
--- a/src/commands/roadmap-tools.js
+++ b/src/commands/roadmap-tools.js
@@ -35,34 +35,127 @@ function parseModelSizeGB(value) {
     return amount * 0.55;
 }
 
-function flattenGPUs(hardware = {}) {
-    const gpus = [];
-    const backends = hardware.backends || {};
+function inferGPUInventoryType(gpu = {}, backend = '') {
+    const explicitType = String(gpu.type || '').toLowerCase();
+    if (explicitType === 'integrated' || explicitType === 'dedicated') return explicitType;
+    if (backend === 'metal') return 'integrated';
 
-    for (const [backend, data] of Object.entries(backends)) {
-        if (!data || !data.available || !data.info) continue;
+    const name = String(gpu.name || gpu.model || '').toLowerCase();
+    const dedicatedPattern = /(geforce|\brtx\b|\bgtx\b|radeon\s*(?:\(tm\))?\s*rx|\brx\s?\d|quadro|tesla|instinct|\barc\s*a\d|a\d{3,}|h100|h200|l40)/i;
+    if (dedicatedPattern.test(name)) return 'dedicated';
 
-        if (Array.isArray(data.info.gpus) && data.info.gpus.length > 0) {
-            for (const gpu of data.info.gpus) {
-                gpus.push({
-                    backend,
-                    name: gpu.name || `${backend.toUpperCase()} GPU`,
-                    vramGB: gpu.memory?.total || 0,
-                    speedCoefficient: gpu.speedCoefficient || 0
-                });
-            }
-            continue;
-        }
+    const integratedPattern = /(intel|iris|uhd|hd graphics|radeon.*graphics|\b\d{3,4}m\b|vega|apple|tegra|jetson)/i;
+    return integratedPattern.test(name) ? 'integrated' : 'dedicated';
+}
 
-        // Apple Metal detector reports a single GPU differently.
-        if (backend === 'metal') {
-            gpus.push({
+function getGPUModelMatchKey(name) {
+    const lower = String(name || '').toLowerCase();
+    if (!lower) return '';
+
+    // Dedicated backends and systeminformation often describe the same card
+    // differently (for example "RTX 3090" vs "GA102 [GeForce RTX 3090]").
+    const familyMatch = lower.match(/\b(rtx|gtx|rx|arc)\s*[- ]?([a-z]?\d{3,4})\b/);
+    if (familyMatch) return `${familyMatch[1]}${familyMatch[2]}`;
+
+    const acceleratorMatch = lower.match(/\b(a\d{3,4}|h\d{3,4}|l\d{2}s?|mi\d{2,4}x?)\b/);
+    if (acceleratorMatch) return acceleratorMatch[1];
+
+    const bracketPciId = lower.match(/\[[0-9a-f]{4}:([0-9a-f]{4})\]/);
+    if (bracketPciId) return `pci:${bracketPciId[1]}`;
+    const barePciId = lower.match(/\bdevice\s+([0-9a-f]{4})\b/);
+    if (barePciId) return `pci:${barePciId[1]}`;
+
+    return lower
+        .replace(/nvidia|amd|ati|intel|corporation|geforce|radeon|graphics/g, '')
+        .replace(/[^a-z0-9]+/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function getGPUCrossBackendKeys(gpu = {}, backend = '') {
+    const keys = new Set();
+    const type = inferGPUInventoryType(gpu, backend);
+
+    for (const uuid of [gpu.uuid, gpu.gpuUuid, gpu.gpuUUID]) {
+        const normalized = String(uuid || '').trim().toLowerCase();
+        if (normalized) keys.add(`uuid:${normalized}`);
+    }
+
+    for (const address of [gpu.pciBus, gpu.busAddress, gpu.pcie?.busId, gpu.pcie?.busAddress]) {
+        const raw = String(address || '').trim().toLowerCase();
+        const normalized = raw.match(/([0-9a-f]{2}:[0-9a-f]{2}\.[0-7])$/)?.[1] || raw;
+        if (normalized) keys.add(`pci-bus:${normalized}`);
+    }
+
+    const modelKey = getGPUModelMatchKey(gpu.name || gpu.model);
+    if (modelKey) keys.add(`model:${modelKey}|${type}`);
+
+    return keys;
+}
+
+function getBackendGPUEntries(backend, data) {
+    if (!data || !data.available || !data.info) return [];
+
+    if (Array.isArray(data.info.gpus) && data.info.gpus.length > 0) {
+        return data.info.gpus.map((gpu) => ({
+            backend,
+            source: gpu,
+            flattened: {
                 backend,
-                name: data.info.chip || 'Apple Silicon GPU',
-                vramGB: data.info.memory?.unified || 0,
+                name: gpu.name || `${backend.toUpperCase()} GPU`,
+                vramGB: gpu.memory?.total || 0,
+                speedCoefficient: gpu.speedCoefficient || 0
+            }
+        }));
+    }
+
+    // Apple Metal detector reports a single GPU differently.
+    if (backend === 'metal') {
+        const source = {
+            name: data.info.chip || 'Apple Silicon GPU',
+            type: 'integrated',
+            memory: { total: data.info.memory?.unified || 0 }
+        };
+        return [{
+            backend,
+            source,
+            flattened: {
+                backend,
+                name: source.name,
+                vramGB: source.memory.total,
                 speedCoefficient: data.info.speedCoefficient || 0
-            });
+            }
+        }];
+    }
+
+    return [];
+}
+
+function flattenGPUs(hardware = {}) {
+    const backends = hardware.backends || {};
+    const entries = Object.entries(backends)
+        .flatMap(([backend, data]) => getBackendGPUEntries(backend, data));
+    const specializedKeys = new Set();
+
+    // Dedicated detector output is authoritative. Preserve every entry inside
+    // each specialized backend so two real, identical GPUs remain two devices;
+    // use those identities only to suppress duplicate generic inventory views.
+    for (const entry of entries) {
+        if (entry.backend === 'generic') continue;
+        for (const key of getGPUCrossBackendKeys(entry.source, entry.backend)) {
+            specializedKeys.add(key);
         }
+    }
+
+    const gpus = [];
+    for (const entry of entries) {
+        if (entry.backend === 'generic') {
+            const isDuplicate = Array.from(getGPUCrossBackendKeys(entry.source, entry.backend))
+                .some((key) => specializedKeys.has(key));
+            if (isDuplicate) continue;
+        }
+
+        gpus.push(entry.flattened);
     }
 
     return gpus;

--- a/tests/roadmap-tools.test.js
+++ b/tests/roadmap-tools.test.js
@@ -61,10 +61,164 @@ class RoadmapToolsTestSuite {
         };
 
         const plan = buildGpuPlan(hardware, { modelSizeGB: 20 });
-        this.assert(plan.gpuCount === 2, 'multi-gpu count detected');
+        this.assert(plan.gpuCount === 2, 'two identical GPUs in one backend remain two devices');
+        this.assert(plan.totalVRAM === 48, 'same-backend multi-GPU VRAM remains pooled');
         this.assert(plan.strategy === 'distributed', 'multi-gpu strategy is distributed');
         this.assert(plan.fit.fitsPooled === true, '20GB target fits pooled envelope');
         this.assert(plan.env.OLLAMA_SCHED_SPREAD === '1', 'spread scheduling enabled for multi-gpu');
+    }
+
+    testGpuPlanDeduplicatesCudaGenericAlias() {
+        this.log('\n--- buildGpuPlan CUDA/generic deduplication ---');
+        const hardware = {
+            summary: { bestBackend: 'cuda', effectiveMemory: 24 },
+            backends: {
+                cuda: {
+                    available: true,
+                    info: {
+                        gpus: [{
+                            index: 0,
+                            name: 'NVIDIA GeForce RTX 3090',
+                            uuid: 'GPU-822c0482-9be5-example',
+                            memory: { total: 24 },
+                            speedCoefficient: 200
+                        }]
+                    }
+                },
+                generic: {
+                    available: true,
+                    info: {
+                        gpus: [{
+                            name: 'GA102 [GeForce RTX 3090]',
+                            vendor: 'NVIDIA',
+                            type: 'dedicated',
+                            memory: { total: 24 }
+                        }]
+                    }
+                }
+            }
+        };
+
+        const plan = buildGpuPlan(hardware, { modelSizeGB: 16 });
+        this.assert(plan.gpuCount === 1, 'CUDA and generic aliases collapse to one physical GPU');
+        this.assert(plan.gpus[0]?.backend === 'cuda', 'specialized CUDA entry wins over generic fallback');
+        this.assert(plan.totalVRAM === 24, 'duplicate generic VRAM is not pooled twice');
+        this.assert(plan.singleMaxModelGB === 22, 'single-GPU safe envelope remains 22GB');
+        this.assert(plan.pooledMaxModelGB === 22, 'pooled envelope remains 22GB for one GPU');
+        this.assert(plan.strategy === 'single_gpu', 'deduplicated host uses single-GPU strategy');
+        this.assert(plan.env.OLLAMA_SCHED_SPREAD === '0', 'spread scheduling stays disabled');
+        this.assert(plan.env.OLLAMA_NUM_PARALLEL === '1', 'single-GPU parallel recommendation stays at one');
+        this.assert(plan.env.OLLAMA_MAX_LOADED_MODELS === '1', 'single-GPU loaded-model limit stays at one');
+    }
+
+    testGpuPlanPreservesDistinctGenericIgpu() {
+        this.log('\n--- buildGpuPlan distinct generic iGPU ---');
+        const hardware = {
+            summary: { bestBackend: 'cuda', effectiveMemory: 24 },
+            backends: {
+                generic: {
+                    available: true,
+                    info: {
+                        gpus: [
+                            {
+                                name: 'GA102 [GeForce RTX 3090]',
+                                vendor: 'NVIDIA',
+                                type: 'dedicated',
+                                memory: { total: 24 }
+                            },
+                            {
+                                name: 'Intel Iris Xe Graphics',
+                                vendor: 'Intel',
+                                type: 'integrated',
+                                memory: { total: 8 }
+                            }
+                        ]
+                    }
+                },
+                cuda: {
+                    available: true,
+                    info: {
+                        gpus: [{
+                            name: 'NVIDIA GeForce RTX 3090',
+                            memory: { total: 24 },
+                            speedCoefficient: 200
+                        }]
+                    }
+                }
+            }
+        };
+
+        const plan = buildGpuPlan(hardware);
+        this.assert(plan.gpuCount === 2, 'distinct generic iGPU remains visible beside CUDA GPU');
+        this.assert(
+            plan.gpus.filter((gpu) => gpu.name.includes('RTX 3090')).length === 1,
+            'generic copy of CUDA GPU is still removed on a hybrid host'
+        );
+        this.assert(
+            plan.gpus.some((gpu) => gpu.backend === 'generic' && gpu.name.includes('Iris Xe')),
+            'distinct integrated GPU is preserved'
+        );
+    }
+
+    testGpuPlanPreservesGenericOnlyInventory() {
+        this.log('\n--- buildGpuPlan generic-only inventory ---');
+        const hardware = {
+            summary: { bestBackend: 'cpu', effectiveMemory: 32 },
+            backends: {
+                generic: {
+                    available: true,
+                    info: {
+                        gpus: [{
+                            name: 'AMD Radeon RX 7800 XT',
+                            vendor: 'AMD',
+                            type: 'dedicated',
+                            memory: { total: 16 }
+                        }]
+                    }
+                }
+            }
+        };
+
+        const plan = buildGpuPlan(hardware);
+        this.assert(plan.gpuCount === 1, 'generic-only GPU inventory is retained');
+        this.assert(plan.gpus[0]?.backend === 'generic', 'generic-only entry keeps its backend label');
+        this.assert(plan.totalVRAM === 16, 'generic-only VRAM remains available to the plan');
+    }
+
+    testGpuPlanDeduplicatesRocmGenericAlias() {
+        this.log('\n--- buildGpuPlan ROCm/generic deduplication ---');
+        const hardware = {
+            summary: { bestBackend: 'rocm', effectiveMemory: 24 },
+            backends: {
+                rocm: {
+                    available: true,
+                    info: {
+                        gpus: [{
+                            name: 'AMD Radeon RX 7900 XTX',
+                            memory: { total: 24 },
+                            speedCoefficient: 180
+                        }]
+                    }
+                },
+                generic: {
+                    available: true,
+                    info: {
+                        gpus: [{
+                            name: 'Navi 31 [Radeon RX 7900 XTX]',
+                            vendor: 'AMD',
+                            type: 'dedicated',
+                            memory: { total: 24 }
+                        }]
+                    }
+                }
+            }
+        };
+
+        const plan = buildGpuPlan(hardware);
+        this.assert(plan.gpuCount === 1, 'ROCm and generic aliases collapse to one physical GPU');
+        this.assert(plan.gpus[0]?.backend === 'rocm', 'specialized ROCm entry wins over generic fallback');
+        this.assert(plan.totalVRAM === 24, 'ROCm VRAM is not double-counted');
+        this.assert(plan.strategy === 'single_gpu', 'deduplicated ROCm host uses single-GPU strategy');
     }
 
     testContextVerification() {
@@ -136,6 +290,10 @@ class RoadmapToolsTestSuite {
 
         this.testParseModelSize();
         this.testGpuPlan();
+        this.testGpuPlanDeduplicatesCudaGenericAlias();
+        this.testGpuPlanPreservesDistinctGenericIgpu();
+        this.testGpuPlanPreservesGenericOnlyInventory();
+        this.testGpuPlanDeduplicatesRocmGenericAlias();
         this.testContextVerification();
         this.testAmdGuard();
         this.testToolcheckEvaluation();


### PR DESCRIPTION
## Summary

- reconcile specialized accelerator backends with the generic `systeminformation` inventory before planning
- prefer CUDA/ROCm/Intel/Metal entries over duplicate generic views of the same physical GPU
- preserve two identical physical GPUs reported by one specialized backend
- retain distinct integrated GPUs and generic-only inventories
- use UUID/PCI identity when available, then a normalized model+type fallback

This prevents a single RTX 3090 from becoming a fake 2-GPU/48GB distributed plan when CUDA and the generic fallback both report it.

## Validation

- `npm run test:roadmap` — 36/36
- `npm run test:hardware-detector`
- `npm run test:gpu` — 57/57
- `npm run test:platform` — 32/32
- tier, VRAM, and virtual-monitor regressions
- `npm test` — 54/54 passing

Fixes #108