### PR TITLE
feat: add explicit CPU-only execution mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,26 @@ This makes integrated GPUs visible even when the selected runtime backend is sti
 llm-checker recommend
 ```
 
+### Force CPU-only execution
+
+Use `--cpu-only` when system RAM and CPU are a better fit than the detected GPU. The flag is available on `check`, `recommend`, `ai-check`, `ai-run`, `registry-recommend`, `smart-recommend`, `gpu-plan`, and `hw-detect`:
+
+```bash
+llm-checker recommend --cpu-only --category coding
+llm-checker gpu-plan --cpu-only --model-size 14GB
+llm-checker hw-detect --cpu-only
+```
+
+CPU-only mode still detects GPUs and reports them as diagnostic inventory, but sets active VRAM to zero, selects the CPU backend, and bases fit, tier, scoring, and planning on the detected CPU plus 70% of system RAM. It can also be enabled for all commands in a shell:
+
+```bash
+export LLM_CHECKER_CPU_ONLY=1
+```
+
+Accelerator-only runtimes are excluded in this mode. In particular, `--runtime mlx` falls back to Ollama, while `--runtime auto` only considers runtimes compatible with the CPU-only hardware projection.
+
+With hardware simulation, the simulated profile is resolved first and the CPU-only override is applied second. For example, `check --simulate rtx4090 --cpu-only` keeps that profile's simulated CPU and RAM while treating its RTX 4090 as diagnostic only. Programmatic callers can pass `{ cpuOnly: false }` explicitly to override an enabled environment variable.
+
 As of the scoring unification (#96), `check`, `recommend`, and `smart-recommend`
 all derive their ranking from **one canonical scoring core**
 (`DeterministicModelSelector` via `src/models/scoring-core.js`), so identical

--- a/analyzer/compatibility.js
+++ b/analyzer/compatibility.js
@@ -280,12 +280,12 @@ class CompatibilityAnalyzer {
 
         switch (arch) {
             case 'Apple Silicon':
-                if (model.frameworks?.includes('llama.cpp')) {
+                if (!hardware.cpuOnly && model.frameworks?.includes('llama.cpp')) {
                     analysis.factor = this.ollamaOptimizations.hardwareOptimizations['Apple Silicon'].metalBonus;
                     analysis.notes.push('Apple Silicon with Metal acceleration');
                 }
 
-                if (model.requirements?.vram === 0) {
+                if (!hardware.cpuOnly && model.requirements?.vram === 0) {
                     analysis.factor *= this.ollamaOptimizations.hardwareOptimizations['Apple Silicon'].unifiedMemoryBonus;
                     analysis.notes.push('🔄 Unified memory architecture advantage');
                 }
@@ -395,7 +395,7 @@ class CompatibilityAnalyzer {
             analysis.recommendations.push('Enable GPU acceleration in Ollama');
         }
 
-        if (hardware.cpu.architecture === 'Apple Silicon') {
+        if (!hardware.cpuOnly && hardware.cpu.architecture === 'Apple Silicon') {
             analysis.recommendations.push('Ollama will use Metal acceleration automatically');
         }
 
@@ -469,7 +469,7 @@ class CompatibilityAnalyzer {
             recommendations.push('💾 Upgrade to 16GB+ RAM for better compatibility');
         }
 
-        if (!hardware.gpu.dedicated && hardware.memory.total >= 16) {
+        if (!hardware.cpuOnly && !hardware.gpu.dedicated && hardware.memory.total >= 16) {
             recommendations.push('🎮 Consider dedicated GPU for significant speedup');
         }
 
@@ -510,7 +510,7 @@ class CompatibilityAnalyzer {
         if (options.includeOllamaOptimizations !== false) {
             recommendations.push('Install Ollama for easy model management');
 
-            if (hardware.cpu.architecture === 'Apple Silicon') {
+            if (!hardware.cpuOnly && hardware.cpu.architecture === 'Apple Silicon') {
                 recommendations.push('Ollama will use Metal acceleration automatically');
             }
 

--- a/bin/enhanced_cli.js
+++ b/bin/enhanced_cli.js
@@ -18,6 +18,7 @@ const { getLogger } = require('../src/utils/logger');
 const fs = require('fs');
 const path = require('path');
 const { normalizePlatform, isTermuxEnvironment } = require('../src/utils/platform');
+const { resolveCpuOnlyMode } = require('../src/hardware/cpu-only');
 const {
     SUPPORTED_RUNTIMES,
     normalizeRuntime,
@@ -95,6 +96,17 @@ function displayRecommendationCommandNote(command) {
     if (!note) return;
     console.log(chalk.gray(`Recommendation mode: ${note}`));
     console.log('');
+}
+
+function getCpuOnlyCommandMode(options = {}) {
+    return resolveCpuOnlyMode(options.cpuOnly ? true : undefined);
+}
+
+function displayCpuOnlyModeNotice(cpuOnly, simulated = false) {
+    if (!cpuOnly) return;
+    const source = simulated ? 'Simulated CPU and RAM are retained; simulated GPU is diagnostic only.' : 'Detected GPU inventory is diagnostic only.';
+    console.log(chalk.yellow.bold('\n  CPU-ONLY MODE: GPU acceleration and VRAM are disabled.'));
+    console.log(chalk.gray(`  ${source}\n`));
 }
 
 // Function to search Ollama models by use case
@@ -1378,27 +1390,41 @@ function getOllamaCommand(modelName) {
 }
 
 function displaySystemInfo(hardware, analysis) {
+    const cpuOnly = Boolean(hardware.cpuOnly);
     const cpuColor = hardware.cpu.cores >= 8 ? chalk.green : hardware.cpu.cores >= 4 ? chalk.yellow : chalk.red;
     const ramColor = hardware.memory.total >= 32 ? chalk.green : hardware.memory.total >= 16 ? chalk.yellow : chalk.red;
-    const gpuColor = hardware.gpu.dedicated ? chalk.green : chalk.hex('#FFA500');
-    const integratedList = formatGpuInventoryList(hardware.gpu.integratedGpuModels || hardware.summary?.integratedGpuModels);
-    const dedicatedList = formatGpuInventoryList(hardware.gpu.dedicatedGpuModels || hardware.summary?.dedicatedGpuModels);
+    const gpuColor = cpuOnly ? chalk.gray : (hardware.gpu.dedicated ? chalk.green : chalk.hex('#FFA500'));
+    const integratedInventory = cpuOnly
+        ? hardware.detectedGpu?.integratedGpuModels
+        : (hardware.gpu.integratedGpuModels || hardware.summary?.integratedGpuModels);
+    const dedicatedInventory = cpuOnly
+        ? hardware.detectedGpu?.dedicatedGpuModels
+        : (hardware.gpu.dedicatedGpuModels || hardware.summary?.dedicatedGpuModels);
+    const integratedList = formatGpuInventoryList(integratedInventory);
+    const dedicatedList = formatGpuInventoryList(dedicatedInventory);
     const integratedSharedMemory = hardware.gpu.sharedMemory || hardware.summary?.integratedSharedMemory || 0;
-    const vramDisplay = !hardware.gpu.dedicated && integratedSharedMemory > 0
+    const vramDisplay = cpuOnly
+        ? 'Disabled (CPU-only)'
+        : (!hardware.gpu.dedicated && integratedSharedMemory > 0
         ? `${integratedSharedMemory}GB shared`
         : (hardware.gpu.vram === 0 && hardware.gpu.model && hardware.gpu.model.toLowerCase().includes('apple')
             ? 'Unified Memory'
-            : `${hardware.gpu.vram || 'N/A'}GB`);
+            : `${hardware.gpu.vram || 'N/A'}GB`));
+    const gpuDisplay = cpuOnly ? 'Disabled by CPU-only mode' : (hardware.gpu.model || 'Not detected');
+    const gpuTypeSuffix = cpuOnly
+        ? ''
+        : (hardware.gpu.dedicated ? chalk.green(' (Dedicated)') : chalk.hex('#FFA500')(' (Integrated)'));
+    const inventorySuffix = cpuOnly ? ' (diagnostic)' : '';
 
     const lines = [
         `${chalk.cyan('CPU:')} ${cpuColor(hardware.cpu.brand)} ${chalk.gray(`(${hardware.cpu.cores} cores, ${hardware.cpu.speed}GHz)`)}`,
         `${chalk.cyan('Architecture:')} ${hardware.cpu.architecture}`,
         `${chalk.cyan('RAM:')} ${ramColor(hardware.memory.total + 'GB')}`,
-        `${chalk.cyan('GPU:')} ${gpuColor(hardware.gpu.model || 'Not detected')}`,
+        `${chalk.cyan('GPU:')} ${gpuColor(gpuDisplay)}`,
         `${chalk.cyan('Backend:')} ${chalk.white(getBackendLabelForDisplay(hardware))}`,
-        `${chalk.cyan('VRAM:')} ${vramDisplay}${hardware.gpu.dedicated ? chalk.green(' (Dedicated)') : chalk.hex('#FFA500')(' (Integrated)')}`,
-        `${chalk.cyan('Dedicated GPUs:')} ${chalk.green(dedicatedList)}`,
-        `${chalk.cyan('Integrated GPUs:')} ${chalk.hex('#FFA500')(integratedList)}`,
+        `${chalk.cyan('VRAM:')} ${vramDisplay}${gpuTypeSuffix}`,
+        `${chalk.cyan(`Dedicated GPUs${inventorySuffix}:`)} ${chalk.green(dedicatedList)}`,
+        `${chalk.cyan(`Integrated GPUs${inventorySuffix}:`)} ${chalk.hex('#FFA500')(integratedList)}`,
     ];
 
     const tier = analysis.summary.hardwareTier?.replace(/_/g, ' ').toUpperCase() || getHardwareTierForDisplay(hardware);
@@ -3750,6 +3776,7 @@ program
     .option('--show-ollama-analysis', 'Show detailed Ollama model analysis')
     .option('--no-verbose', 'Disable step-by-step progress display')
     .option('--simulate <profile>', 'Simulate a hardware profile instead of detecting real hardware (use "list" to see profiles)')
+    .option('--cpu-only', 'Force CPU/RAM execution even when a GPU is detected')
     .option('--gpu <model>', 'Custom GPU model for simulation (e.g., "RTX 5060", "RX 7800 XT")')
     .option('--ram <gb>', 'Custom RAM in GB for simulation (e.g., 32)')
     .option('--cpu <model>', 'Custom CPU model for simulation (e.g., "AMD Ryzen 7 5700X")')
@@ -3765,8 +3792,12 @@ Enterprise policy examples:
 Hardware simulation:
   $ llm-checker check --simulate list
   $ llm-checker check --simulate rtx4090
+  $ llm-checker check --simulate rtx4090 --cpu-only
   $ llm-checker check --simulate m4pro24 --use-case coding
   $ llm-checker check --gpu "RTX 5060" --ram 32 --cpu "AMD Ryzen 7 5700X"
+
+CPU-only precedence:
+  - --cpu-only keeps the selected real/simulated CPU and RAM, but disables its GPU for fit and scoring
 
 Policy scope:
   - Evaluates all compatible and marginal candidates discovered during analysis
@@ -3779,7 +3810,8 @@ Policy scope:
         try {
             // Use verbose progress unless explicitly disabled
             const verboseEnabled = options.verbose !== false;
-            const checker = new (getLLMChecker())({ verbose: verboseEnabled });
+            const cpuOnly = getCpuOnlyCommandMode(options);
+            const checker = new (getLLMChecker())({ verbose: verboseEnabled, cpuOnly });
             const policyConfig = options.policy ? loadPolicyConfiguration(options.policy) : null;
 
             // Handle hardware simulation (preset profile or custom flags)
@@ -3831,6 +3863,7 @@ Policy scope:
                 checker.setSimulatedHardware(simulatedHardware);
                 console.log(chalk.magenta.bold(`\n  SIMULATION MODE: ${displayLabel}\n`));
             }
+            displayCpuOnlyModeNotice(cpuOnly, checker.isSimulated);
 
             // If verbose is disabled, show simple loading message
             if (!verboseEnabled) {
@@ -3891,7 +3924,8 @@ Policy scope:
                 maxSize: maxSize,
                 minSize: minSize,
                 runtime: selectedRuntime,
-                includeUncensored: options.includeUncensored === true
+                includeUncensored: options.includeUncensored === true,
+                cpuOnly
             });
 
             if (!verboseEnabled) {
@@ -4379,6 +4413,7 @@ program
     .option('--no-verbose', 'Disable step-by-step progress display')
     .option('--policy <file>', 'Evaluate recommendations against a policy file')
     .option('--simulate <profile>', 'Simulate a hardware profile instead of detecting real hardware (use "list" to see profiles)')
+    .option('--cpu-only', 'Force CPU/RAM execution even when a GPU is detected')
     .option('--gpu <model>', 'Custom GPU model for simulation (e.g., "RTX 5060", "RX 7800 XT")')
     .option('--ram <gb>', 'Custom RAM in GB for simulation (e.g., 32)')
     .option('--cpu <model>', 'Custom CPU model for simulation (e.g., "AMD Ryzen 7 5700X")')
@@ -4397,8 +4432,12 @@ Enterprise policy examples:
 
 Hardware simulation:
   $ llm-checker recommend --simulate rtx4090
+  $ llm-checker recommend --simulate rtx4090 --cpu-only
   $ llm-checker recommend --simulate m4pro24 --category coding
   $ llm-checker recommend --gpu "RTX 5060" --ram 32 --cpu "AMD Ryzen 7 5700X"
+
+CPU-only precedence:
+  - --cpu-only keeps the selected real/simulated CPU and RAM, but disables its GPU for fit and scoring
 
 Registry/runtime examples:
   $ llm-checker recommend --runtime auto --category coding
@@ -4416,7 +4455,8 @@ Calibrated routing examples:
         displayRecommendationCommandNote('recommend');
         try {
             const verboseEnabled = options.verbose !== false;
-            const checker = new (getLLMChecker())({ verbose: verboseEnabled });
+            const cpuOnly = getCpuOnlyCommandMode(options);
+            const checker = new (getLLMChecker())({ verbose: verboseEnabled, cpuOnly });
 
             // Handle hardware simulation (preset profile or custom flags)
             const hasCustomHwFlags = options.gpu || options.ram || options.cpu || options.vram;
@@ -4467,6 +4507,7 @@ Calibrated routing examples:
                 checker.setSimulatedHardware(simulatedHardware);
                 console.log(chalk.magenta.bold(`\n  SIMULATION MODE: ${displayLabel}\n`));
             }
+            displayCpuOnlyModeNotice(cpuOnly, checker.isSimulated);
 
             const routingPreference = resolveRoutingPolicyPreference({
                 policyOption: options.policy,
@@ -4481,11 +4522,24 @@ Calibrated routing examples:
             }
 
             const hardware = await checker.getSystemInfo();
+            let recommendationRuntime = options.runtime;
+            const requestedRuntimeName = String(options.runtime || 'auto').toLowerCase();
+            if (
+                !['auto', 'all', '*'].includes(requestedRuntimeName) &&
+                !runtimeSupportedOnHardware(options.runtime, hardware)
+            ) {
+                const runtimeLabel = getRuntimeDisplayName(options.runtime);
+                console.log(chalk.yellow(
+                    `${runtimeLabel} is not compatible with CPU-only/current hardware; using Ollama instead.`
+                ));
+                recommendationRuntime = 'ollama';
+            }
             const intelligentRecommendations = await checker.generateIntelligentRecommendations(hardware, {
                 optimizeFor: options.optimize,
-                runtime: options.runtime,
+                runtime: recommendationRuntime,
                 registry: options.registry,
-                includeUncensored: options.includeUncensored === true
+                includeUncensored: options.includeUncensored === true,
+                cpuOnly
             });
 
             if (!intelligentRecommendations) {
@@ -4951,6 +5005,7 @@ program
     .option('-w, --weight <number>', 'AI weight (0.0-1.0, default 0.3)', '0.3')
     .option('-m, --models <list>', 'Restrict evaluation to these models (comma-separated)')
     .option('--include-uncensored', 'Explicitly include uncensored, abliterated, or heretic models')
+    .option('--cpu-only', 'Force CPU/RAM execution even when a GPU is detected')
     .action(async (options) => {
         showAsciiArt('ai-check');
         // Check if Ollama is installed first
@@ -4959,9 +5014,10 @@ program
         const AICheckSelector = require('../src/models/ai-check-selector');
         
         try {
+            const cpuOnly = getCpuOnlyCommandMode(options);
             const spinner = ora('AI-Check Mode: Meta-evaluation in progress...').start();
             
-            const aiCheckSelector = new AICheckSelector();
+            const aiCheckSelector = new AICheckSelector({ cpuOnly });
             
             // Validate numeric options up front: bad input (e.g. --weight abc, --top
             // foo) used to flow through as NaN, which survived the downstream clamp
@@ -4988,10 +5044,12 @@ program
                 evaluator: options.evaluator,
                 weight,
                 models: options.models || process.env.LLM_CHECKER_AI_CHECK_MODELS || undefined,
+                cpuOnly,
                 includeUncensored: options.includeUncensored === true
             };
 
             spinner.stop();
+            displayCpuOnlyModeNotice(cpuOnly);
             
             const result = await aiCheckSelector.aiCheck(checkOptions);
             
@@ -5021,6 +5079,7 @@ program
     .option('--benchmark', 'Run a short local speed test before launching')
     .option('--reference-only', 'Show model choice and speed reference without launching Ollama')
     .option('--include-uncensored', 'Explicitly include uncensored, abliterated, or heretic models')
+    .option('--cpu-only', 'Force CPU/RAM model selection even when a GPU is detected')
     .option('--verify', 'Verify the selected model blob with modelvet before running (fails closed unless ACCEPT)')
     .option('--allow-unverified', 'Continue only when --verify cannot produce a verdict; never bypasses REJECT')
     .action(async (options) => {
@@ -5035,16 +5094,18 @@ program
         const AIModelSelector = require('../src/ai/model-selector');
         
         try {
+            const cpuOnly = getCpuOnlyCommandMode(options);
+            displayCpuOnlyModeNotice(cpuOnly);
             const spinner = ora('Selecting best model and launching...').start();
             
-            const aiSelector = new AIModelSelector();
-            const checker = new (getLLMChecker())();
-            const systemInfo = await checker.getSystemInfo();
+            const aiSelector = new AIModelSelector({ cpuOnly });
+            const checker = new (getLLMChecker())({ cpuOnly });
+            const systemInfo = await checker.getSystemInfo({ cpuOnly });
             let ollamaClient = null;
             const getOllamaClient = () => {
                 if (!ollamaClient) {
                     const OllamaClient = require('../src/ollama/client');
-                    ollamaClient = new OllamaClient();
+                    ollamaClient = new OllamaClient({ cpuOnly });
                 }
                 return ollamaClient;
             };
@@ -5099,9 +5160,10 @@ program
                 cpu_cores: systemInfo.cpu?.cores || 4,
                 cpu_freq_max: systemInfo.cpu?.speed || 3.0,
                 total_ram_gb: systemInfo.memory?.total || 8,
-                gpu_vram_gb: systemInfo.gpu?.vram || 0,
-                gpu_model_normalized: systemInfo.gpu?.model || 
+                gpu_vram_gb: cpuOnly ? 0 : (systemInfo.gpu?.vram || 0),
+                gpu_model_normalized: cpuOnly ? 'cpu_only' : (systemInfo.gpu?.model ||
                     (systemInfo.cpu?.manufacturer === 'Apple' ? 'apple_silicon' : 'cpu_only')
+                )
             };
 
             const taskHint = normalizeTaskName(options.category || inferTaskFromPrompt(options.prompt));
@@ -5127,7 +5189,8 @@ program
                 }
                 result = await aiSelector.selectBestModel(candidateModels, systemSpecs, taskHint, {
                     silent: true,
-                    includeUncensored: options.includeUncensored === true
+                    includeUncensored: options.includeUncensored === true,
+                    cpuOnly
                 });
             }
             
@@ -5480,6 +5543,7 @@ program
     .option('--include-uncensored', 'Explicitly include uncensored, abliterated, or heretic models')
     .option('--pool-limit <n>', 'Maximum registry artifacts to score before ranking', '20000')
     .option('-l, --limit <n>', 'Maximum number of recommendations', '10')
+    .option('--cpu-only', 'Force CPU/RAM execution even when a GPU is detected')
     .option('-j, --json', 'Output as JSON')
     .action(async (query = '', options) => {
         try {
@@ -5501,9 +5565,10 @@ program
         const spinner = options.json ? null : ora('Scoring registry artifacts...').start();
 
         try {
+            const cpuOnly = getCpuOnlyCommandMode(options);
             await recommender.initialize();
 
-            const detector = new UnifiedDetector();
+            const detector = new UnifiedDetector({ cpuOnly });
             const hardware = await detector.detect();
             const category = normalizeTaskName(options.category || 'general');
             const result = await recommender.recommend({
@@ -5522,6 +5587,7 @@ program
                 includeUncensored: options.includeUncensored === true,
                 poolLimit: parsePositiveNumberOption(options.poolLimit, 20000),
                 limit: parsePositiveNumberOption(options.limit, 10),
+                cpuOnly,
                 hardware
             });
 
@@ -5539,6 +5605,16 @@ program
                     `Scored ${result.total_evaluated} candidates from ${result.total_artifacts} registry artifacts`
                 );
             }
+            const requestedRuntime = String(options.runtime || 'auto').toLowerCase();
+            if (
+                !['auto', 'all', '*'].includes(requestedRuntime) &&
+                String(result.runtime || '').toLowerCase() !== requestedRuntime
+            ) {
+                console.log(chalk.yellow(
+                    `${getRuntimeDisplayName(options.runtime)} is not compatible with CPU-only/current hardware; using ${getRuntimeDisplayName(result.runtime)} instead.`
+                ));
+            }
+            displayCpuOnlyModeNotice(cpuOnly);
 
             if (result.recommendations.length === 0) {
                 console.log(chalk.yellow('No registry recommendations found for those filters.'));
@@ -5746,6 +5822,7 @@ program
     .option('--include-vision', 'Include vision/multimodal models')
     .option('--include-embeddings', 'Include embedding models')
     .option('--include-uncensored', 'Explicitly include uncensored, abliterated, or heretic models')
+    .option('--cpu-only', 'Force CPU/RAM execution even when a GPU is detected')
     .option('-j, --json', 'Output as JSON')
     .addHelpText(
         'after',
@@ -5767,8 +5844,9 @@ Recommendation engine note:
         const spinner = options.json ? null : ora('Analyzing hardware and models...').start();
 
         try {
+            const cpuOnly = getCpuOnlyCommandMode(options);
             // Detect hardware
-            const detector = new UnifiedDetector();
+            const detector = new UnifiedDetector({ cpuOnly });
             const hardware = await detector.detect();
 
             if (spinner) spinner.text = 'Loading model database...';
@@ -5790,7 +5868,7 @@ Recommendation engine note:
             if (spinner) spinner.text = `Scoring ${variants.length} model variants...`;
 
             // Get intelligent recommendations
-            const selector = new IntelligentSelector({ detector });
+            const selector = new IntelligentSelector({ detector, cpuOnly });
             const recommendations = await selector.recommend(variants, {
                 useCase: options.useCase,
                 targetTPS: parseInt(options.targetTps) || 20,
@@ -5798,6 +5876,7 @@ Recommendation engine note:
                 includeVision: options.includeVision,
                 includeEmbeddings: options.includeEmbeddings,
                 includeUncensored: options.includeUncensored === true,
+                cpuOnly,
                 limit: parseInt(options.limit)
             });
 
@@ -5809,6 +5888,7 @@ Recommendation engine note:
             }
 
             if (spinner) spinner.succeed('Analysis complete!');
+            displayCpuOnlyModeNotice(cpuOnly);
 
             // Display hardware info
             console.log(chalk.blue.bold('\n=== Hardware Analysis ==='));
@@ -5899,6 +5979,7 @@ program
     .command('gpu-plan')
     .description('Multi-GPU placement advisor with safe model-size envelopes')
     .option('--model-size <gb>', 'Validate a target model size (e.g. 14 or 14GB)')
+    .option('--cpu-only', 'Force a CPU/RAM plan and ignore detected GPU capacity')
     .option('-j, --json', 'Output as JSON')
     .action(async (options) => {
         if (!options.json) showAsciiArt('hw-detect');
@@ -5908,7 +5989,8 @@ program
             const UnifiedDetector = require('../src/hardware/unified-detector');
             const { buildGpuPlan } = require('../src/commands/roadmap-tools');
 
-            const detector = new UnifiedDetector();
+            const cpuOnly = getCpuOnlyCommandMode(options);
+            const detector = new UnifiedDetector({ cpuOnly });
             const hardware = await detector.detect();
 
             const modelSizeGB = options.modelSize !== undefined ? parseFloat(options.modelSize) : null;
@@ -5916,7 +5998,7 @@ program
                 throw new Error('Invalid --model-size value. Use a positive number (GB).');
             }
 
-            const plan = buildGpuPlan(hardware, { modelSizeGB });
+            const plan = buildGpuPlan(hardware, { modelSizeGB, cpuOnly });
 
             if (options.json) {
                 console.log(JSON.stringify(plan, null, 2));
@@ -5924,13 +6006,18 @@ program
             }
 
             if (spinner) spinner.succeed('GPU placement plan ready');
+            displayCpuOnlyModeNotice(cpuOnly);
 
             console.log(chalk.blue.bold('\n=== Multi-GPU Placement Plan ==='));
             console.log(`Backend: ${chalk.cyan((plan.backend || 'cpu').toUpperCase())}`);
             console.log(`Detected GPUs: ${chalk.white(plan.gpuCount)}`);
             console.log(`Total VRAM/Unified: ${chalk.green(`${plan.totalVRAM}GB`)}`);
-            console.log(`Single-GPU safe envelope: ${chalk.yellow(`${plan.singleMaxModelGB}GB`)}`);
-            console.log(`Pooled safe envelope: ${chalk.yellow(`${plan.pooledMaxModelGB}GB`)}`);
+            if (plan.cpuOnly) {
+                console.log(`CPU/RAM safe envelope: ${chalk.yellow(`${plan.cpuMaxModelGB}GB`)}`);
+            } else {
+                console.log(`Single-GPU safe envelope: ${chalk.yellow(`${plan.singleMaxModelGB}GB`)}`);
+                console.log(`Pooled safe envelope: ${chalk.yellow(`${plan.pooledMaxModelGB}GB`)}`);
+            }
             console.log(`Strategy: ${chalk.cyan(plan.strategy)} (${plan.strategyReason})`);
 
             if (plan.gpus.length > 0) {
@@ -5951,10 +6038,15 @@ program
 
             if (plan.fit) {
                 const fit = plan.fit;
-                const status = fit.fitsSingleGPU || fit.fitsPooled ? chalk.green('[OK]') : chalk.red('[FAIL]');
+                const fitsActiveMode = plan.cpuOnly ? fit.fitsCPU : (fit.fitsSingleGPU || fit.fitsPooled);
+                const status = fitsActiveMode ? chalk.green('[OK]') : chalk.red('[FAIL]');
                 console.log(`${status} Target model ${fit.modelSizeGB}GB`);
-                console.log(`   Fits single GPU: ${fit.fitsSingleGPU ? 'yes' : 'no'}`);
-                console.log(`   Fits pooled setup: ${fit.fitsPooled ? 'yes' : 'no'}`);
+                if (plan.cpuOnly) {
+                    console.log(`   Fits CPU/RAM budget: ${fit.fitsCPU ? 'yes' : 'no'}`);
+                } else {
+                    console.log(`   Fits single GPU: ${fit.fitsSingleGPU ? 'yes' : 'no'}`);
+                    console.log(`   Fits pooled setup: ${fit.fitsPooled ? 'yes' : 'no'}`);
+                }
             }
 
             console.log(chalk.blue.bold('\nRecommended env:'));
@@ -6361,6 +6453,7 @@ program
 program
     .command('hw-detect')
     .description('Detect and display detailed hardware capabilities')
+    .option('--cpu-only', 'Force CPU/RAM execution while retaining GPU inventory as diagnostics')
     .option('-j, --json', 'Output as JSON')
     .action(async (options) => {
         if (!options.json) showAsciiArt('hw-detect');
@@ -6369,7 +6462,8 @@ program
         const spinner = options.json ? null : ora('Detecting hardware...').start();
 
         try {
-            const detector = new UnifiedDetector();
+            const cpuOnly = getCpuOnlyCommandMode(options);
+            const detector = new UnifiedDetector({ cpuOnly });
             const hardware = await detector.detect();
 
             if (options.json) {
@@ -6378,6 +6472,7 @@ program
             }
 
             if (spinner) spinner.succeed('Hardware detected!');
+            displayCpuOnlyModeNotice(cpuOnly);
 
             console.log(chalk.blue.bold('\n=== Hardware Detection ===\n'));
 
@@ -6390,8 +6485,15 @@ program
             if (hardware.summary.runtimeBackend && hardware.summary.runtimeBackend !== hardware.summary.bestBackend) {
                 console.log(`  Runtime assist: ${chalk.green(hardware.summary.runtimeBackendName || hardware.summary.runtimeBackend)}`);
             }
-            console.log(`  Dedicated GPUs: ${chalk.green(formatGpuInventoryList(hardware.summary.dedicatedGpuModels))}`);
-            console.log(`  Integrated GPUs: ${chalk.hex('#FFA500')(formatGpuInventoryList(hardware.summary.integratedGpuModels))}`);
+            const inventorySummary = hardware.cpuOnly && hardware.detectedGpu
+                ? {
+                    dedicatedGpuModels: hardware.detectedGpu.dedicatedGpuModels || [],
+                    integratedGpuModels: hardware.detectedGpu.integratedGpuModels || []
+                }
+                : hardware.summary;
+            const inventoryLabel = hardware.cpuOnly ? ' (diagnostic)' : '';
+            console.log(`  Dedicated GPUs${inventoryLabel}: ${chalk.green(formatGpuInventoryList(inventorySummary.dedicatedGpuModels))}`);
+            console.log(`  Integrated GPUs${inventoryLabel}: ${chalk.hex('#FFA500')(formatGpuInventoryList(inventorySummary.integratedGpuModels))}`);
             if (hardware.summary.hasIntegratedGPU && hardware.summary.bestBackend === 'cpu') {
                 const assistMessage = hardware.summary.runtimeBackend && hardware.summary.runtimeBackend !== hardware.summary.bestBackend
                     ? `Integrated/shared-memory GPU detected, runtime may use ${hardware.summary.runtimeBackendName || hardware.summary.runtimeBackend} acceleration`

--- a/bin/mcp-server.mjs
+++ b/bin/mcp-server.mjs
@@ -31,6 +31,7 @@ const require = createRequire(import.meta.url);
 // model files (verify-before-load). Loaded via createRequire because this
 // server is ESM and the verifier is CommonJS.
 const modelvet = require("../src/security/modelvet-verifier.js");
+const { resolveCpuOnlyMode } = require("../src/hardware/cpu-only.js");
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
@@ -131,6 +132,26 @@ function tryParseJSON(text) {
   } catch {
     return null;
   }
+}
+
+function buildOllamaGenerationPayload(body = {}, cpuOnly = resolveCpuOnlyMode()) {
+  if (!cpuOnly) return body;
+  return {
+    ...body,
+    options: {
+      ...(body.options || {}),
+      num_gpu: 0,
+    },
+  };
+}
+
+function applyCpuOnlyOptimizationEnv(envVars = {}, cpuOnly = resolveCpuOnlyMode()) {
+  if (!cpuOnly) return envVars;
+  return {
+    ...envVars,
+    OLLAMA_NUM_GPU: "0",
+    OLLAMA_FLASH_ATTENTION: "0",
+  };
 }
 
 // ----------------------------------------------------------------------------
@@ -910,7 +931,11 @@ server.tool(
   },
   async ({ model, prompt }) => {
     try {
-      const data = await ollamaAPI("/api/generate", { model, prompt, stream: false }, 300000);
+      const data = await ollamaAPI(
+        "/api/generate",
+        buildOllamaGenerationPayload({ model, prompt, stream: false }),
+        300000
+      );
       const tokPerSec = formatTokPerSec(tokensPerSecond(data.eval_count, data.eval_duration));
       const result = [
         `MODEL: ${model}`,
@@ -957,6 +982,7 @@ server.tool(
       const hwJsonText = await run(["hw-detect", "--json"]);
       const hwJson = tryParseJSON(hwJsonText);
       const { tier, vramGB } = mapHardwareJson(hwJson || {});
+      const cpuOnly = Boolean(hwJson?.cpuOnly) || resolveCpuOnlyMode();
 
       const totalMem = os.totalmem();
       const freeMem = os.freemem();
@@ -999,14 +1025,14 @@ server.tool(
       if (totalGB >= 32) keepAlive = "15m";
       if (totalGB >= 64) keepAlive = "30m";
 
-      const envVars = {
+      const envVars = applyCpuOnlyOptimizationEnv({
         OLLAMA_NUM_GPU: String(numGPU),
         OLLAMA_NUM_PARALLEL: String(numParallel),
         OLLAMA_MAX_LOADED_MODELS: String(maxLoaded),
         OLLAMA_FLASH_ATTENTION: flashAttn,
         OLLAMA_KEEP_ALIVE: keepAlive,
         OLLAMA_NUM_CTX: String(ctxSize),
-      };
+      }, cpuOnly);
 
       // Shell export commands
       const exportLines = Object.entries(envVars)
@@ -1023,12 +1049,13 @@ server.tool(
         `====================================`,
         `Hardware: ${cpuCount} cores, ${totalGB}GB total RAM, ${freeGB}GB free`,
         `Platform: ${platform} | Tier: ${tier}${vramGB !== null ? ` | VRAM: ${vramGB}GB` : ""}`,
+        `Execution mode: ${cpuOnly ? "CPU-only (GPU disabled)" : "automatic"}`,
         ``,
         `RECOMMENDED ENVIRONMENT VARIABLES:`,
         `----------------------------------`,
         ...Object.entries(envVars).map(([k, v]) => {
           const desc = {
-            OLLAMA_NUM_GPU: "GPU layers (999 = all layers offloaded to GPU)",
+            OLLAMA_NUM_GPU: "GPU layers (0 = CPU-only, 999 = all layers offloaded to GPU)",
             OLLAMA_NUM_PARALLEL: "Concurrent request slots",
             OLLAMA_MAX_LOADED_MODELS: "Models kept in memory simultaneously",
             OLLAMA_FLASH_ATTENTION: "Flash attention for faster inference",
@@ -1084,7 +1111,7 @@ server.tool(
       for (let i = 0; i < iterations; i++) {
         const data = await ollamaAPI(
           "/api/generate",
-          { model, prompt: benchPrompt, stream: false },
+          buildOllamaGenerationPayload({ model, prompt: benchPrompt, stream: false }),
           300000
         );
 
@@ -1172,8 +1199,16 @@ server.tool(
     try {
       // M3: run sequentially so the two models do not contend for GPU/RAM.
       // Each measurement is taken while the other model is not executing.
-      const resultA = await ollamaAPI("/api/generate", { model: model_a, prompt: testPrompt, stream: false }, 300000);
-      const resultB = await ollamaAPI("/api/generate", { model: model_b, prompt: testPrompt, stream: false }, 300000);
+      const resultA = await ollamaAPI(
+        "/api/generate",
+        buildOllamaGenerationPayload({ model: model_a, prompt: testPrompt, stream: false }),
+        300000
+      );
+      const resultB = await ollamaAPI(
+        "/api/generate",
+        buildOllamaGenerationPayload({ model: model_b, prompt: testPrompt, stream: false }),
+        300000
+      );
 
       function metrics(data) {
         const evalTokens = data.eval_count || 0;
@@ -1606,6 +1641,8 @@ export {
   tokensPerSecond,
   formatTokPerSec,
   mapHardwareJson,
+  buildOllamaGenerationPayload,
+  applyCpuOnlyOptimizationEnv,
   detectFrameworkMarker,
   FRAMEWORK_MARKERS,
   canonicalPath,

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:policy-audit": "node tests/policy-audit-reporter.test.js",
     "test:policy-e2e": "node tests/policy-e2e-integration.test.js",
     "test:hardware-detector": "node tests/hardware-detector-regression.js",
+    "test:cpu-only": "node tests/cpu-only-mode.test.js",
     "test:all": "node tests/run-all-tests.js",
     "build": "echo 'No build needed'",
     "dev": "node bin/enhanced_cli.js",

--- a/src/ai/model-selector.js
+++ b/src/ai/model-selector.js
@@ -2,12 +2,35 @@ const path = require('path');
 const fs = require('fs');
 const IntelligentModelSelector = require('./intelligent-selector');
 const { filterModelsBySafety } = require('../models/model-safety');
+const { resolveCpuOnlyMode } = require('../hardware/cpu-only');
 
 class AIModelSelector {
-    constructor() {
+    constructor(options = {}) {
         this.aiSelectorPath = path.join(__dirname, '../../ml-model/js');
         this.isAvailable = this.checkAvailability();
         this.intelligentSelector = new IntelligentModelSelector();
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
+    }
+
+    normalizeSystemSpecs(systemSpecs = null, options = {}) {
+        const cpuOnly = Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+            ? resolveCpuOnlyMode(options.cpuOnly)
+            : this.cpuOnly;
+        const normalized = systemSpecs || {
+            total_ram_gb: 8,
+            gpu_vram_gb: 0,
+            cpu_cores: 4,
+            gpu_model_normalized: 'cpu_only'
+        };
+
+        if (!cpuOnly) return normalized;
+
+        return {
+            ...normalized,
+            cpu_only: true,
+            gpu_vram_gb: 0,
+            gpu_model_normalized: 'cpu_only'
+        };
     }
 
     checkAvailability() {
@@ -37,6 +60,7 @@ class AIModelSelector {
     async selectBestModel(candidateModels, systemSpecs = null, userPreference = 'general', options = {}) {
         const log = options.silent ? () => {} : console.log;
         const warn = options.silent ? () => {} : console.warn;
+        systemSpecs = this.normalizeSystemSpecs(systemSpecs, options);
         candidateModels = filterModelsBySafety(candidateModels, {
             includeUncensored: options.includeUncensored === true
         });
@@ -227,6 +251,7 @@ class AIModelSelector {
     fallbackSelection(candidateModels, systemSpecs = null, options = {}) {
         const log = options.silent ? () => {} : console.log;
         const warn = options.silent ? () => {} : console.warn;
+        systemSpecs = this.normalizeSystemSpecs(systemSpecs, options);
         candidateModels = filterModelsBySafety(candidateModels, {
             includeUncensored: options.includeUncensored === true
         });
@@ -235,15 +260,6 @@ class AIModelSelector {
                 'No eligible models remain after the default safety filter. ' +
                 'Re-run with --include-uncensored to opt in.'
             );
-        }
-
-        if (!systemSpecs) {
-            systemSpecs = {
-                total_ram_gb: 8,
-                gpu_vram_gb: 0,
-                cpu_cores: 4,
-                gpu_model_normalized: 'cpu_only'
-            };
         }
 
         log('🔄 Using fallback heuristic selection...');

--- a/src/ai/multi-objective-selector.js
+++ b/src/ai/multi-objective-selector.js
@@ -12,6 +12,7 @@ const { MULTI_OBJECTIVE_WEIGHTS } = require('../models/scoring-config');
 const { normalizePlatform } = require('../utils/platform');
 const { rankModels } = require('../models/scoring-core');
 const { filterModelsBySafety } = require('../models/model-safety');
+const { applyCpuOnlyOverride } = require('../hardware/cpu-only');
 
 class MultiObjectiveSelector {
     constructor(options = {}) {
@@ -67,12 +68,22 @@ class MultiObjectiveSelector {
             return { compatible: [], marginal: [], incompatible: [] };
         }
 
+        const effectiveHardware = applyCpuOnlyOverride(hardware, {
+            ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                ? { cpuOnly: options.cpuOnly }
+                : {}),
+            source: 'multi-objective-selector'
+        });
+
         let ranking;
         try {
-            ranking = await this.rankModels(eligibleModels, hardware, {
+            ranking = await this.rankModels(eligibleModels, effectiveHardware, {
                 category,
                 topN: eligibleModels.length,
-                includeUncensored: options.includeUncensored === true
+                includeUncensored: options.includeUncensored === true,
+                ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                    ? { cpuOnly: options.cpuOnly }
+                    : {})
             });
         } catch (error) {
             ranking = null;
@@ -81,7 +92,7 @@ class MultiObjectiveSelector {
         // Defensive fallback: if the unified core is unavailable for any reason,
         // fall back to the legacy multi-objective ranking so `check` still works.
         if (!ranking || !Array.isArray(ranking.candidates)) {
-            return this.selectBestModelsLegacy(hardware, eligibleModels, category, topK);
+            return this.selectBestModelsLegacy(effectiveHardware, eligibleModels, category, topK);
         }
 
         const scoredModels = [];
@@ -90,7 +101,12 @@ class MultiObjectiveSelector {
             const source = candidate?.meta?.__source;
             if (!source) continue;
             rankedSources.add(source);
-            scoredModels.push(this.mapCoreCandidateToMultiObjective(candidate, source, hardware, category));
+            scoredModels.push(this.mapCoreCandidateToMultiObjective(
+                candidate,
+                source,
+                effectiveHardware,
+                category
+            ));
         }
 
         // Models the canonical core dropped (category filter / budget) are not
@@ -231,6 +247,13 @@ class MultiObjectiveSelector {
     }
 
     getAvailableModelMemoryGB(hardware, fallbackRatio = 0.7) {
+        if (hardware?.cpuOnly) {
+            const effectiveMemory = Number(hardware?.summary?.effectiveMemory);
+            if (Number.isFinite(effectiveMemory) && effectiveMemory > 0) {
+                return effectiveMemory;
+            }
+        }
+
         const ramGB = Number(hardware?.memory?.total ?? hardware?.memory?.totalGB ?? 0) || 0;
         const vramGB = Number(
             hardware?.gpu?.vram ??
@@ -473,6 +496,21 @@ class MultiObjectiveSelector {
     }
 
     getHardwareTier(hardware) {
+        if (hardware?.cpuOnly) {
+            const canonicalTier = String(hardware?.summary?.hardwareTier || 'ultra_low');
+            const cpuOnlyTierMap = {
+                ultra_high: 'ultra_high',
+                very_high: 'ultra_high',
+                high: 'high',
+                medium_high: 'medium',
+                medium: 'medium',
+                medium_low: 'low',
+                low: 'low',
+                ultra_low: 'ultra_low'
+            };
+            return cpuOnlyTierMap[canonicalTier] || 'ultra_low';
+        }
+
         // Use the same advanced scoring algorithm for consistency
         const clamp = (x, a = 0, b = 1) => Math.max(a, Math.min(b, x));
         
@@ -993,7 +1031,8 @@ class MultiObjectiveSelector {
 
     estimateTTFB(hardware, model) {
         const sizeGB = this.parseModelSize(model.size);
-        const loadTime = sizeGB * (hardware.gpu ? 50 : 100); // ms per GB
+        const usesGpu = !hardware?.cpuOnly && Boolean(hardware.gpu);
+        const loadTime = sizeGB * (usesGpu ? 50 : 100); // ms per GB
         return Math.max(200, loadTime);
     }
 

--- a/src/commands/roadmap-tools.js
+++ b/src/commands/roadmap-tools.js
@@ -6,6 +6,12 @@
  * - toolcheck
  */
 
+const {
+    applyCpuOnlyOverride,
+    getCpuOnlyMaxModelSize,
+    resolveCpuOnlyMode
+} = require('../hardware/cpu-only');
+
 function clamp(value, min, max) {
     return Math.max(min, Math.min(max, value));
 }
@@ -163,8 +169,14 @@ function flattenGPUs(hardware = {}) {
 
 function buildGpuPlan(hardware = {}, options = {}) {
     const modelSizeGB = parseModelSizeGB(options.modelSizeGB);
-    const summary = hardware.summary || {};
-    const gpus = flattenGPUs(hardware).sort((a, b) => {
+    const cpuOnly = Boolean(hardware.cpuOnly) || resolveCpuOnlyMode(
+        Object.prototype.hasOwnProperty.call(options, 'cpuOnly') ? options.cpuOnly : undefined
+    );
+    const effectiveHardware = cpuOnly
+        ? applyCpuOnlyOverride(hardware, { cpuOnly: true, source: 'gpu-plan' })
+        : hardware;
+    const summary = effectiveHardware.summary || {};
+    const gpus = (cpuOnly ? [] : flattenGPUs(effectiveHardware)).sort((a, b) => {
         if (b.vramGB !== a.vramGB) return b.vramGB - a.vramGB;
         return b.speedCoefficient - a.speedCoefficient;
     });
@@ -175,12 +187,16 @@ function buildGpuPlan(hardware = {}, options = {}) {
     const strongestVRAM = strongest ? strongest.vramGB : 0;
     const pooledMaxModelGB = clamp(totalVRAM - 2, 0, Number.MAX_SAFE_INTEGER);
     const singleMaxModelGB = clamp(strongestVRAM - 2, 0, Number.MAX_SAFE_INTEGER);
+    const cpuMaxModelGB = cpuOnly ? getCpuOnlyMaxModelSize(effectiveHardware) : 0;
     const backend = summary.bestBackend || 'cpu';
 
     let strategy = 'cpu_fallback';
     let strategyReason = 'No compatible GPU backend detected.';
 
-    if (gpuCount === 1) {
+    if (cpuOnly) {
+        strategy = 'cpu_only';
+        strategyReason = 'CPU-only override active; detected GPU inventory is ignored and model fit uses system RAM.';
+    } else if (gpuCount === 1) {
         strategy = 'single_gpu';
         strategyReason = `One ${backend.toUpperCase()} GPU detected; keep model weights on a single device.`;
     } else if (gpuCount > 1) {
@@ -199,11 +215,17 @@ function buildGpuPlan(hardware = {}, options = {}) {
     const fit = modelSizeGB === null ? null : {
         modelSizeGB,
         fitsSingleGPU: modelSizeGB <= singleMaxModelGB,
-        fitsPooled: modelSizeGB <= pooledMaxModelGB
+        fitsPooled: modelSizeGB <= pooledMaxModelGB,
+        ...(cpuOnly ? { fitsCPU: modelSizeGB <= cpuMaxModelGB } : {})
     };
 
     const recommendations = [];
-    if (gpuCount > 1) {
+    if (cpuOnly) {
+        recommendations.push(
+            `Keep model payload <= ${round1(cpuMaxModelGB)}GB for the active CPU/RAM budget.`,
+            'Detected GPUs are diagnostic only while CPU-only mode is active.'
+        );
+    } else if (gpuCount > 1) {
         recommendations.push(
             `Prefer model sizes <= ${round1(singleMaxModelGB)}GB for deterministic single-GPU residency.`,
             `Pooled envelope is ~${round1(pooledMaxModelGB)}GB if scheduling spreads the load.`
@@ -216,17 +238,22 @@ function buildGpuPlan(hardware = {}, options = {}) {
 
     return {
         backend,
+        cpuOnly,
+        memoryType: cpuOnly ? 'system_ram' : 'vram',
+        memoryBudgetGB: cpuOnly ? round1(summary.effectiveMemory || 0) : totalVRAM,
         gpuCount,
         gpus,
         totalVRAM,
         strongestGPU: strongest,
         singleMaxModelGB: round1(singleMaxModelGB),
         pooledMaxModelGB: round1(pooledMaxModelGB),
+        cpuMaxModelGB: round1(cpuMaxModelGB),
         strategy,
         strategyReason,
         env,
         fit,
-        recommendations
+        recommendations,
+        detectedGpu: cpuOnly ? effectiveHardware.detectedGpu : undefined
     };
 }
 

--- a/src/data/registry-recommender.js
+++ b/src/data/registry-recommender.js
@@ -1,5 +1,7 @@
 const ModelDatabase = require('./model-database');
 const DeterministicModelSelector = require('../models/deterministic-selector');
+const { applyCpuOnlyOverride } = require('../hardware/cpu-only');
+const { runtimeSupportedOnHardware } = require('../runtime/runtime-support');
 
 function toArray(value) {
     return Array.isArray(value) ? value : [];
@@ -361,7 +363,14 @@ function candidateToRecommendation(candidate) {
     };
 }
 
-function normalizeHardwareForSelector(hardware = {}) {
+function normalizeHardwareForSelector(hardware = {}, options = {}) {
+    hardware = applyCpuOnlyOverride(hardware, {
+        ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+            ? { cpuOnly: options.cpuOnly }
+            : {}),
+        source: 'registry-recommender'
+    });
+
     if (hardware.memory?.totalGB && hardware.gpu && hardware.acceleration) {
         return hardware;
     }
@@ -378,25 +387,30 @@ function normalizeHardwareForSelector(hardware = {}) {
     const isRocm = bestBackend === 'rocm';
 
     return {
+        ...hardware,
         cpu: {
+            ...cpuInfo,
             architecture: cpuInfo.architecture || process.arch,
             cores: Number(cpuCores.logical || cpuCores.physical || cpuInfo.cores || 4),
             model: cpuInfo.brand || summary.cpuModel || ''
         },
         gpu: {
+            ...(hardware.gpu || {}),
             type: isMetal ? 'apple_silicon' : (isCuda ? 'nvidia' : (isRocm ? 'amd' : 'cpu_only')),
             model: gpuModel,
             vramGB: totalVRAM,
             totalVRAM,
-            gpuCount: Math.max(1, Number(summary.gpuCount || 1)),
+            gpuCount: hardware.cpuOnly ? 0 : Math.max(1, Number(summary.gpuCount || 1)),
             unified: Boolean(isMetal || (summary.hasIntegratedGPU && !summary.hasDedicatedGPU)),
-            isMultiGPU: Boolean(summary.isMultiGPU)
+            isMultiGPU: hardware.cpuOnly ? false : Boolean(summary.isMultiGPU)
         },
         memory: {
+            ...(hardware.memory || {}),
             totalGB: systemRAM,
             total: systemRAM
         },
         acceleration: {
+            ...(hardware.acceleration || {}),
             supports_metal: isMetal,
             supports_cuda: isCuda,
             supports_rocm: isRocm
@@ -432,7 +446,17 @@ class RegistryRecommender {
 
     async selectCategory(options = {}) {
         const category = options.category || 'general';
-        const runtime = options.runtime || 'auto';
+        const selectorHardware = normalizeHardwareForSelector(options.hardware || {}, {
+            ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                ? { cpuOnly: options.cpuOnly }
+                : {})
+        });
+        const requestedRuntime = options.runtime || 'auto';
+        const requestedRuntimeName = String(requestedRuntime).toLowerCase();
+        const runtime = !['auto', 'all', '*'].includes(requestedRuntimeName) &&
+            !runtimeSupportedOnHardware(requestedRuntime, selectorHardware)
+            ? 'ollama'
+            : requestedRuntime;
         const runtimeFilter = ['auto', 'all', '*'].includes(String(runtime).toLowerCase()) ? undefined : runtime;
         const limit = Number(options.limit) > 0 ? Number(options.limit) : 10;
         const poolLimit = Number(options.poolLimit) > 0 ? Number(options.poolLimit) : 20000;
@@ -451,7 +475,6 @@ class RegistryRecommender {
         });
         const modelPool = dedupeRecommendationPool(rows.map(artifactToSelectorModel).filter(Boolean));
 
-        const selectorHardware = normalizeHardwareForSelector(options.hardware || {});
         const normalizedRuntime = runtimeFilter || 'auto';
 
         // No registry artifacts matched the filters: return an empty result rather
@@ -484,6 +507,9 @@ class RegistryRecommender {
                 optimizeFor: options.optimizeFor || 'balanced',
                 runtime: runtimeFilter,
                 targetCtx,
+                ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                    ? { cpuOnly: options.cpuOnly }
+                    : {}),
                 hardware: selectorHardware,
                 installedModels: [],
                 modelPool,
@@ -494,6 +520,9 @@ class RegistryRecommender {
                 limit: rankWindow,
                 targetCtx,
                 optimizeFor: options.optimizeFor || 'balanced',
+                ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                    ? { cpuOnly: options.cpuOnly }
+                    : {}),
                 hardware: selectorHardware,
                 modelPool,
                 includeUncensored: options.includeUncensored === true
@@ -543,7 +572,8 @@ class RegistryRecommender {
                     ].filter(Boolean).join('|'));
                 }
                 const normalizedHardware = this.selector.normalizeHardwareProfile(
-                    normalizeHardwareForSelector(hardware || {})
+                    normalizeHardwareForSelector(hardware || {}, options),
+                    options
                 );
                 recommendations[category] = {
                     tier: this.selector.mapHardwareTier(normalizedHardware),
@@ -579,8 +609,20 @@ class RegistryRecommender {
         };
     }
 
-    scoreAutoRuntimePool({ category, limit, targetCtx, optimizeFor, hardware, modelPool, includeUncensored = false }) {
-        const normalizedHardware = this.selector.normalizeHardwareProfile(hardware);
+    scoreAutoRuntimePool({
+        category,
+        limit,
+        targetCtx,
+        optimizeFor,
+        hardware,
+        modelPool,
+        cpuOnly,
+        includeUncensored = false
+    }) {
+        const normalizedHardware = this.selector.normalizeHardwareProfile(
+            hardware,
+            cpuOnly === undefined ? {} : { cpuOnly }
+        );
         const objective = this.selector.normalizeOptimizationObjective(optimizeFor);
         const ctx = targetCtx || this.selector.targetContexts[category] || this.selector.targetContexts.general;
         const totalMem = normalizedHardware?.memory?.totalGB ?? normalizedHardware?.memory?.total ?? 8;
@@ -594,11 +636,19 @@ class RegistryRecommender {
         const candidates = [];
 
         for (const model of filtered) {
-            const runtime = model.preferredRuntime || choosePreferredRuntime(
+            const preferredRuntime = model.preferredRuntime || choosePreferredRuntime(
                 model.artifact?.runtime_support,
                 model.artifact?.format,
                 model.source
             );
+            const runtimeCandidates = [
+                preferredRuntime,
+                ...toArray(model.artifact?.runtime_support)
+            ].filter((runtime, index, values) => runtime && values.indexOf(runtime) === index);
+            const runtime = runtimeCandidates.find((candidateRuntime) =>
+                runtimeSupportedOnHardware(candidateRuntime, normalizedHardware)
+            );
+            if (!runtime) continue;
             const candidate = this.selector.evaluateModel(
                 model,
                 normalizedHardware,

--- a/src/hardware/cpu-only.js
+++ b/src/hardware/cpu-only.js
@@ -1,0 +1,319 @@
+'use strict';
+
+const CPU_ONLY_ENV = 'LLM_CHECKER_CPU_ONLY';
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+
+function parseBooleanOptIn(value) {
+    if (typeof value === 'boolean') return value;
+    if (value === null || value === undefined) return false;
+    return TRUE_VALUES.has(String(value).trim().toLowerCase());
+}
+
+function resolveCpuOnlyMode(explicit, env = process.env) {
+    if (explicit !== undefined && explicit !== null) {
+        return parseBooleanOptIn(explicit);
+    }
+    return parseBooleanOptIn(env?.[CPU_ONLY_ENV]);
+}
+
+function toFiniteNumber(value) {
+    if (value === null || value === undefined) return null;
+    if (typeof value === 'string' && value.trim() === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getSystemRAMGB(hardware = {}) {
+    const candidates = [
+        hardware.summary?.systemRAM,
+        hardware.memory?.totalGB,
+        hardware.memory?.total,
+        hardware.total_ram_gb,
+        hardware.memoryGB,
+        hardware.ramGB
+    ];
+
+    for (const candidate of candidates) {
+        const value = toFiniteNumber(candidate);
+        if (value !== null && value > 0) return value;
+    }
+
+    return 8;
+}
+
+function getCpuSpeedCoefficient(hardware = {}) {
+    const candidates = [
+        hardware.cpu?.speedCoefficient,
+        hardware.backends?.cpu?.info?.speedCoefficient,
+        hardware.cpu?.score,
+        hardware.summary?.bestBackend === 'cpu' ? hardware.summary?.speedCoefficient : null
+    ];
+
+    for (const candidate of candidates) {
+        const value = toFiniteNumber(candidate);
+        if (value !== null && value >= 0) return value;
+    }
+
+    return 30;
+}
+
+function getCpuOnlyEffectiveMemoryGB(hardware = {}) {
+    const totalRAM = getSystemRAMGB(hardware);
+    return Math.max(1, Math.round(totalRAM * 0.7));
+}
+
+function classifyCpuOnlyTier(effectiveMemory, speedCoefficient) {
+    const effectiveMem = Number(effectiveMemory) || 0;
+    const speed = Number(speedCoefficient) || 0;
+
+    if (effectiveMem >= 80 && speed >= 300) return 'ultra_high';
+    if (effectiveMem >= 48 && speed >= 200) return 'very_high';
+    if (effectiveMem >= 24 && speed >= 150) return 'high';
+    if (effectiveMem >= 16 && speed >= 100) return 'medium_high';
+    if (effectiveMem >= 12 && speed >= 80) return 'medium';
+    if (effectiveMem >= 8 && speed >= 50) return 'medium_low';
+    if (effectiveMem >= 6 && speed >= 30) return 'low';
+    return 'ultra_low';
+}
+
+function normalizeGpuInventoryEntry(entry) {
+    if (typeof entry === 'string') {
+        const name = entry.trim();
+        return name ? { name, count: 1 } : null;
+    }
+    if (!entry || typeof entry !== 'object') return null;
+
+    const name = String(entry.name || entry.model || '').trim();
+    if (!name || /^(?:no gpu detected|none|unknown|disabled by cpu-only mode)$/i.test(name)) {
+        return null;
+    }
+    const parsedCount = toFiniteNumber(entry.count);
+    return {
+        name,
+        count: parsedCount !== null && parsedCount > 0 ? parsedCount : 1
+    };
+}
+
+function collapseGpuInventory(entries = []) {
+    const counts = new Map();
+    for (const entry of entries) {
+        const normalized = normalizeGpuInventoryEntry(entry);
+        if (!normalized) continue;
+        counts.set(normalized.name, (counts.get(normalized.name) || 0) + normalized.count);
+    }
+    return Array.from(counts, ([name, count]) => ({ name, count }));
+}
+
+function inferGpuInventories(hardware = {}) {
+    const summary = hardware.summary || {};
+    const gpu = hardware.gpu || {};
+    const existingDedicated = Array.isArray(summary.dedicatedGpuModels)
+        ? summary.dedicatedGpuModels
+        : gpu.dedicatedGpuModels;
+    const existingIntegrated = Array.isArray(summary.integratedGpuModels)
+        ? summary.integratedGpuModels
+        : gpu.integratedGpuModels;
+
+    let dedicatedGpuModels = collapseGpuInventory(existingDedicated);
+    let integratedGpuModels = collapseGpuInventory(existingIntegrated);
+    if (dedicatedGpuModels.length && integratedGpuModels.length) {
+        return { dedicatedGpuModels, integratedGpuModels };
+    }
+
+    let candidates = Array.isArray(gpu.all) ? gpu.all : [];
+    if (candidates.length === 0 && Array.isArray(summary.gpuModels)) {
+        candidates = summary.gpuModels;
+    }
+    if (candidates.length === 0) {
+        const model = summary.gpuModel || gpu.model;
+        if (model) candidates = [{ model }];
+    }
+
+    const inferredDedicated = [];
+    const inferredIntegrated = [];
+    for (const candidate of candidates) {
+        const normalized = normalizeGpuInventoryEntry(candidate);
+        if (!normalized) continue;
+
+        const candidateDetails = typeof candidate === 'object' && candidate ? candidate : {};
+        const unified = candidateDetails.unified === true || gpu.unified === true;
+        const dedicated = candidateDetails.dedicated !== undefined
+            ? candidateDetails.dedicated === true
+            : (gpu.dedicated !== undefined
+                ? gpu.dedicated === true
+                : Boolean(summary.hasDedicatedGPU && !summary.hasIntegratedGPU));
+        (unified || !dedicated ? inferredIntegrated : inferredDedicated).push(normalized);
+    }
+
+    if (dedicatedGpuModels.length === 0) {
+        dedicatedGpuModels = collapseGpuInventory(inferredDedicated);
+    }
+    if (integratedGpuModels.length === 0) {
+        integratedGpuModels = collapseGpuInventory(inferredIntegrated);
+    }
+    return { dedicatedGpuModels, integratedGpuModels };
+}
+
+function buildDetectedGpuDiagnostic(hardware = {}) {
+    if (hardware.detectedGpu) return hardware.detectedGpu;
+
+    const summary = hardware.summary || {};
+    const gpu = hardware.gpu || null;
+    const { dedicatedGpuModels, integratedGpuModels } = inferGpuInventories(hardware);
+    const canonicalGpuModels = collapseGpuInventory(summary.gpuModels);
+    const gpuModels = canonicalGpuModels.length > 0
+        ? canonicalGpuModels
+        : collapseGpuInventory([...dedicatedGpuModels, ...integratedGpuModels]);
+    const availableBackends = Object.entries(hardware.backends || {})
+        .filter(([backend, info]) => backend !== 'cpu' && info?.available)
+        .map(([backend]) => backend);
+
+    return {
+        primary: hardware.primary ? {
+            type: hardware.primary.type || null,
+            name: hardware.primary.name || null
+        } : null,
+        backend: summary.bestBackend || hardware.primary?.type || gpu?.backend || null,
+        runtimeBackend: summary.runtimeBackend || null,
+        model: summary.gpuModel || gpu?.model || null,
+        inventory: summary.gpuInventory || gpu?.gpuInventory || null,
+        models: gpuModels,
+        dedicatedGpuModels,
+        integratedGpuModels,
+        totalVRAM: toFiniteNumber(summary.totalVRAM) ??
+            toFiniteNumber(gpu?.totalVRAM) ??
+            toFiniteNumber(gpu?.vramGB) ??
+            toFiniteNumber(gpu?.vram) ??
+            0,
+        gpuCount: toFiniteNumber(summary.gpuCount) ??
+            toFiniteNumber(gpu?.gpuCount) ??
+            (Array.isArray(gpu?.all) ? gpu.all.length : 0),
+        isMultiGPU: Boolean(summary.isMultiGPU || gpu?.isMultiGPU),
+        hasDedicatedGPU: dedicatedGpuModels.length > 0 ||
+            Boolean(summary.hasDedicatedGPU || gpu?.hasDedicatedGPU || gpu?.dedicated),
+        hasIntegratedGPU: integratedGpuModels.length > 0 ||
+            Boolean(summary.hasIntegratedGPU || gpu?.hasIntegratedGPU || gpu?.unified),
+        availableBackends,
+        gpu: gpu ? { ...gpu } : null
+    };
+}
+
+function applyCpuOnlyOverride(hardware = {}, options = {}) {
+    if (!hardware || typeof hardware !== 'object') return hardware;
+
+    const hasExplicitOption = Object.prototype.hasOwnProperty.call(options, 'cpuOnly');
+    const hasHardwareMode = Object.prototype.hasOwnProperty.call(hardware, 'cpuOnly');
+    const enabled = hardware.cpuOnly === true || resolveCpuOnlyMode(
+        hasExplicitOption
+            ? options.cpuOnly
+            : (hasHardwareMode ? hardware.cpuOnly : undefined),
+        options.env || process.env
+    );
+    if (!enabled) return hardware;
+
+    const summary = hardware.summary || {};
+    const totalRAM = getSystemRAMGB(hardware);
+    const effectiveMemory = getCpuOnlyEffectiveMemoryGB(hardware);
+    const speedCoefficient = getCpuSpeedCoefficient(hardware);
+    const cpuInfo = hardware.cpu || hardware.backends?.cpu?.info || null;
+    const detectedGpu = buildDetectedGpuDiagnostic(hardware);
+    const source = hardware.cpuOnlySource || options.source || (
+        hasExplicitOption ? 'explicit' : 'environment'
+    );
+
+    return {
+        ...hardware,
+        cpuOnly: true,
+        cpuOnlySource: source,
+        executionMode: 'cpu_only',
+        backend: 'cpu',
+        totalVRAM: 0,
+        gpuCount: 0,
+        usableMemGB: effectiveMemory,
+        primary: {
+            type: 'cpu',
+            name: 'CPU (forced)',
+            info: cpuInfo
+        },
+        summary: {
+            ...summary,
+            cpuOnly: true,
+            bestBackend: 'cpu',
+            backendName: 'CPU (forced)',
+            bestBackendLabel: 'CPU (forced)',
+            runtimeBackend: 'cpu',
+            runtimeBackendName: 'CPU',
+            hasRuntimeAssist: false,
+            totalVRAM: 0,
+            effectiveMemory,
+            systemRAM: totalRAM,
+            speedCoefficient,
+            isMultiGPU: false,
+            gpuCount: 0,
+            gpuModel: null,
+            gpuInventory: null,
+            gpuModels: [],
+            hasHeterogeneousGPU: false,
+            hasIntegratedGPU: false,
+            hasDedicatedGPU: false,
+            integratedGpuCount: 0,
+            dedicatedGpuCount: 0,
+            integratedGpuModels: [],
+            dedicatedGpuModels: [],
+            integratedSharedMemory: 0,
+            hardwareTier: classifyCpuOnlyTier(effectiveMemory, speedCoefficient)
+        },
+        gpu: {
+            ...(hardware.gpu || {}),
+            type: 'cpu_only',
+            model: 'Disabled by CPU-only mode',
+            vendor: '',
+            backend: 'cpu',
+            vram: 0,
+            vramGB: 0,
+            vramPerGPU: 0,
+            totalVRAM: 0,
+            sharedMemory: 0,
+            dedicatedMemory: 0,
+            dedicated: false,
+            unified: false,
+            gpuCount: 0,
+            isMultiGPU: false,
+            hasIntegratedGPU: false,
+            hasDedicatedGPU: false,
+            integratedGpuCount: 0,
+            dedicatedGpuCount: 0,
+            integratedGpuModels: [],
+            dedicatedGpuModels: [],
+            gpuInventory: null,
+            all: [],
+            score: 0
+        },
+        acceleration: {
+            ...(hardware.acceleration || {}),
+            supports_metal: false,
+            supports_cuda: false,
+            supports_rocm: false,
+            supports_vulkan: false
+        },
+        detectedGpu
+    };
+}
+
+function getCpuOnlyMaxModelSize(hardware = {}, headroomGB = 2) {
+    const effectiveMemory = hardware.cpuOnly
+        ? (toFiniteNumber(hardware.summary?.effectiveMemory) ?? getCpuOnlyEffectiveMemoryGB(hardware))
+        : getCpuOnlyEffectiveMemoryGB(hardware);
+    return Math.max(0, effectiveMemory - Math.max(0, Number(headroomGB) || 0));
+}
+
+module.exports = {
+    CPU_ONLY_ENV,
+    applyCpuOnlyOverride,
+    classifyCpuOnlyTier,
+    getCpuOnlyEffectiveMemoryGB,
+    getCpuOnlyMaxModelSize,
+    getSystemRAMGB,
+    parseBooleanOptIn,
+    resolveCpuOnlyMode
+};

--- a/src/hardware/detector.js
+++ b/src/hardware/detector.js
@@ -1,14 +1,18 @@
 const si = require('systeminformation');
 const UnifiedDetector = require('./unified-detector');
 const { normalizePlatform } = require('../utils/platform');
+const { applyCpuOnlyOverride, resolveCpuOnlyMode } = require('./cpu-only');
 
 class HardwareDetector {
-    constructor() {
+    constructor(options = {}) {
         this.cache = null;
         this.cacheExpiry = 5 * 60 * 1000;
         this.cacheTime = 0;
-        this.unifiedDetector = new UnifiedDetector();
+        // Keep the canonical detector unprojected here. HardwareDetector applies
+        // CPU-only after enrichment so the real GPU remains available as diagnostics.
+        this.unifiedDetector = options.unifiedDetector || new UnifiedDetector({ cpuOnly: false });
         this._simulatedHardware = null;
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
     }
 
     setSimulatedHardware(hardwareObject) {
@@ -19,14 +23,37 @@ class HardwareDetector {
         this._simulatedHardware = null;
     }
 
-    async getSystemInfo(forceFresh = false) {
+    setCpuOnly(enabled = true) {
+        this.cpuOnly = resolveCpuOnlyMode(enabled);
+        return this;
+    }
+
+    applyExecutionMode(hardware, explicitCpuOnly) {
+        const cpuOnly = explicitCpuOnly === undefined
+            ? this.cpuOnly
+            : resolveCpuOnlyMode(explicitCpuOnly);
+        return cpuOnly
+            ? applyCpuOnlyOverride(hardware, { cpuOnly: true, source: 'hardware-detector' })
+            : hardware;
+    }
+
+    async getSystemInfo(forceFresh = false, options = {}) {
+        if (forceFresh && typeof forceFresh === 'object') {
+            options = forceFresh;
+            forceFresh = false;
+        }
+        if (!options || typeof options !== 'object') options = {};
+        const explicitCpuOnly = Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+            ? options.cpuOnly
+            : undefined;
+
         // Return simulated hardware if set (bypasses real detection)
         if (this._simulatedHardware) {
-            return this._simulatedHardware;
+            return this.applyExecutionMode(this._simulatedHardware, explicitCpuOnly);
         }
 
         if (!forceFresh && this.cache && (Date.now() - this.cacheTime < this.cacheExpiry)) {
-            return this.cache;
+            return this.applyExecutionMode(this.cache, explicitCpuOnly);
         }
 
         try {
@@ -52,7 +79,7 @@ class HardwareDetector {
             this.cache = systemInfo;
             this.cacheTime = Date.now();
 
-            return systemInfo;
+            return this.applyExecutionMode(systemInfo, explicitCpuOnly);
         } catch (error) {
             throw new Error(`Failed to detect hardware: ${error.message}`);
         }

--- a/src/hardware/unified-detector.js
+++ b/src/hardware/unified-detector.js
@@ -12,6 +12,7 @@ const CPUDetector = require('./backends/cpu-detector');
 const si = require('systeminformation');
 const { execSync } = require('child_process');
 const { normalizePlatform } = require('../utils/platform');
+const { applyCpuOnlyOverride, resolveCpuOnlyMode } = require('./cpu-only');
 
 // Recent GPUs whose PCI device id is not yet resolved to a model name by the
 // distro pci.ids database (so lspci / systeminformation report them as a bare
@@ -32,7 +33,7 @@ const PCI_GPU_MAP = {
 };
 
 class UnifiedDetector {
-    constructor() {
+    constructor(options = {}) {
         this.backends = {
             metal: new AppleSiliconDetector(),
             cuda: new CUDADetector(),
@@ -44,12 +45,27 @@ class UnifiedDetector {
         this.cache = null;
         this.cacheTime = 0;
         this.cacheExpiry = 5 * 60 * 1000;  // 5 minutes
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
+    }
+
+    setCpuOnly(enabled = true) {
+        const nextValue = resolveCpuOnlyMode(enabled);
+        if (nextValue !== this.cpuOnly) {
+            this.cpuOnly = nextValue;
+            this.cache = null;
+            this.cacheTime = 0;
+        }
+        return this;
     }
 
     /**
      * Detect all available hardware and select the best backend
      */
-    async detect() {
+    async detect(options = {}) {
+        if (options && typeof options === 'object' && Object.prototype.hasOwnProperty.call(options, 'cpuOnly')) {
+            this.setCpuOnly(options.cpuOnly);
+        }
+
         if (this.cache && (Date.now() - this.cacheTime < this.cacheExpiry)) {
             return this.cache;
         }
@@ -172,10 +188,17 @@ class UnifiedDetector {
         // Generate fingerprint
         result.fingerprint = this.generateFingerprint(result);
 
-        this.cache = result;
+        const effectiveResult = this.cpuOnly
+            ? applyCpuOnlyOverride(result, { cpuOnly: true, source: 'detector' })
+            : result;
+        if (this.cpuOnly) {
+            effectiveResult.fingerprint = `${this.backends.cpu.getFingerprint()}-cpu-only`;
+        }
+
+        this.cache = effectiveResult;
         this.cacheTime = Date.now();
 
-        return result;
+        return effectiveResult;
     }
 
     /**

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ const VerboseProgress = require('./utils/verbose-progress');
 const SpeculativeDecodingEstimator = require('./models/speculative-decoding-estimator');
 const {
     normalizeRuntime,
+    runtimeSupportedOnHardware,
     getRuntimePullCommand,
     getRuntimeRunCommand
 } = require('./runtime/runtime-support');
@@ -20,6 +21,7 @@ const {
 } = require('./provenance/model-provenance');
 const { normalizePlatform } = require('./utils/platform');
 const { filterModelsBySafety } = require('./models/model-safety');
+const { applyCpuOnlyOverride, resolveCpuOnlyMode } = require('./hardware/cpu-only');
 
 function filterOllamaIntegrationBySafety(integration = {}, options = {}) {
     const includeUncensored = options.includeUncensored === true;
@@ -50,14 +52,15 @@ function normalizeRecommendationRuntime(runtime = 'auto') {
 
 class LLMChecker {
     constructor(options = {}) {
-        this.hardwareDetector = new HardwareDetector();
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
+        this.hardwareDetector = options.hardwareDetector || new HardwareDetector({ cpuOnly: this.cpuOnly });
         this.expandedModelsDatabase = new ExpandedModelsDatabase();
         this.intelligentRecommender = new DeterministicModelSelector();
         this.ollamaScraper = new OllamaNativeScraper();
         this.compatibilityAnalyzer = new CompatibilityAnalyzer();
         this.performanceAnalyzer = new PerformanceAnalyzer();
         this.speculativeDecodingEstimator = new SpeculativeDecodingEstimator();
-        this.ollamaClient = new OllamaClient();
+        this.ollamaClient = new OllamaClient({ cpuOnly: this.cpuOnly });
         this.logger = getLogger().createChild('LLMChecker');
         this.verbose = options.verbose !== false; // Default to verbose unless explicitly disabled
         this.progress = null; // Will be initialized when needed
@@ -74,11 +77,27 @@ class LLMChecker {
         this._isSimulated = false;
     }
 
+    setCpuOnly(enabled = true) {
+        this.cpuOnly = resolveCpuOnlyMode(enabled);
+        if (typeof this.hardwareDetector.setCpuOnly === 'function') {
+            this.hardwareDetector.setCpuOnly(this.cpuOnly);
+        }
+        if (typeof this.ollamaClient.setCpuOnly === 'function') {
+            this.ollamaClient.setCpuOnly(this.cpuOnly);
+        }
+        return this;
+    }
+
     get isSimulated() {
         return this._isSimulated;
     }
 
     async analyze(options = {}) {
+        const effectiveCpuOnly = Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+            ? resolveCpuOnlyMode(options.cpuOnly)
+            : this.cpuOnly;
+        options = { ...options, cpuOnly: effectiveCpuOnly };
+
         // Initialize verbose progress if enabled
         if (this.verbose && !this.progress) {
             this.progress = VerboseProgress.create(true);
@@ -97,7 +116,9 @@ class LLMChecker {
                 this.progress.step('System Detection', detectionLabel);
             }
             
-            const hardware = await this.hardwareDetector.getSystemInfo();
+            const hardware = await this.hardwareDetector.getSystemInfo(false, {
+                cpuOnly: effectiveCpuOnly
+            });
             this.logger.info('Hardware detected', { hardware });
 
             // Detect platform and route to appropriate logic (use hardware OS for simulation support)
@@ -311,7 +332,10 @@ class LLMChecker {
         const recommendations = await this.generateIntelligentRecommendations(hardware, {
             optimizeFor: options.optimizeFor || options.optimize,
             runtime: options.runtime,
-            includeUncensored: options.includeUncensored === true
+            includeUncensored: options.includeUncensored === true,
+            ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                ? { cpuOnly: options.cpuOnly }
+                : {})
         });
         const intelligentRecommendations = recommendations;
 
@@ -348,7 +372,7 @@ class LLMChecker {
 
     async analyzeWithPlatformSpecificHeuristics(hardware, staticModels, ollamaIntegration, platform, options = {}) {
         // Use different analysis approaches based on platform
-        if (platform === 'apple_silicon') {
+        if (platform === 'apple_silicon' && !hardware.cpuOnly) {
             return await this.analyzeWithAppleSiliconHeuristics(hardware, staticModels, ollamaIntegration, options);
         } else {
             return await this.analyzeWithMathematicalHeuristics(hardware, staticModels, ollamaIntegration, options);
@@ -356,6 +380,15 @@ class LLMChecker {
     }
 
     async analyzeWithAppleSiliconHeuristics(hardware, staticModels, ollamaIntegration, options = {}) {
+        if (hardware.cpuOnly) {
+            return await this.analyzeWithMathematicalHeuristics(
+                hardware,
+                staticModels,
+                ollamaIntegration,
+                options
+            );
+        }
+
         // Apple Silicon specific analysis - more optimistic for unified memory
         this.logger.info('Using Apple Silicon specific heuristics');
         
@@ -366,7 +399,10 @@ class LLMChecker {
         // Use the specified use case, default to 'general'
         const useCase = options.useCase || 'general';
         const results = await selector.selectBestModels(hardware, staticModels, useCase, 100, {
-            includeUncensored: options.includeUncensored === true
+            includeUncensored: options.includeUncensored === true,
+            ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                ? { cpuOnly: options.cpuOnly }
+                : {})
         });
         
         // Apple Silicon specific post-processing - make more models compatible
@@ -630,7 +666,12 @@ class LLMChecker {
                 allUniqueModels,
                 'general',
                 50, // Top 50 modelos
-                { includeUncensored: options.includeUncensored === true }
+                {
+                    includeUncensored: options.includeUncensored === true,
+                    ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                        ? { cpuOnly: options.cpuOnly }
+                        : {})
+                }
             );
             
             this.logger.info(`Multi-objective analysis completed: ${multiObjectiveResult.compatible.length} compatible, ${multiObjectiveResult.marginal.length} marginal`);
@@ -2462,8 +2503,8 @@ class LLMChecker {
         return await this.integrateOllamaModels(await this.getSystemInfo(), []);
     }
 
-    async getSystemInfo() {
-        return await this.hardwareDetector.getSystemInfo();
+    async getSystemInfo(options = {}) {
+        return await this.hardwareDetector.getSystemInfo(false, options);
     }
 
     getAllModels() {
@@ -2517,7 +2558,19 @@ class LLMChecker {
     async generateIntelligentRecommendations(hardware, options = {}) {
         try {
             this.logger.info('Generating intelligent recommendations...');
-            const selectedRuntime = normalizeRecommendationRuntime(options.runtime || 'auto');
+            hardware = applyCpuOnlyOverride(hardware, {
+                cpuOnly: Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                    ? options.cpuOnly
+                    : this.cpuOnly,
+                source: 'llm-checker'
+            });
+            let selectedRuntime = normalizeRecommendationRuntime(options.runtime || 'auto');
+            if (selectedRuntime !== 'auto' && !runtimeSupportedOnHardware(selectedRuntime, hardware)) {
+                this.logger.warn(
+                    `${selectedRuntime} is not compatible with the active hardware mode; falling back to Ollama`
+                );
+                selectedRuntime = 'ollama';
+            }
             const optimizeFor = options.optimizeFor || options.optimize || 'balanced';
 
             if (options.registry !== false) {
@@ -2530,6 +2583,9 @@ class LLMChecker {
                     const registryResult = await registryRecommender.getBestModelsForHardware(hardware, {
                         runtime: selectedRuntime,
                         optimizeFor,
+                        cpuOnly: Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                            ? options.cpuOnly
+                            : this.cpuOnly,
                         limit: 3,
                         poolLimit: options.poolLimit || 20000,
                         localOnly: options.includeGated ? false : true,
@@ -2589,7 +2645,10 @@ class LLMChecker {
                 {
                     optimizeFor,
                     runtime: fallbackRuntime,
-                    includeUncensored: options.includeUncensored === true
+                    includeUncensored: options.includeUncensored === true,
+                    cpuOnly: Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                        ? options.cpuOnly
+                        : this.cpuOnly
                 }
             );
             const summary = this.intelligentRecommender.generateRecommendationSummary(

--- a/src/models/ai-check-selector.js
+++ b/src/models/ai-check-selector.js
@@ -14,12 +14,14 @@ const fs = require('fs');
 const path = require('path');
 const { evaluateFineTuningSupport } = require('./fine-tuning-support');
 const { filterModelsBySafety } = require('./model-safety');
+const { applyCpuOnlyOverride, resolveCpuOnlyMode } = require('../hardware/cpu-only');
 
 class AICheckSelector {
     constructor(options = {}) {
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
         this.deterministicSelector = options.deterministicSelector || new DeterministicModelSelector();
-        this.hardwareDetector = options.hardwareDetector || new HardwareDetector();
-        this.ollamaClient = options.ollamaClient || new OllamaClient();
+        this.hardwareDetector = options.hardwareDetector || new HardwareDetector({ cpuOnly: this.cpuOnly });
+        this.ollamaClient = options.ollamaClient || new OllamaClient({ cpuOnly: this.cpuOnly });
         this.ollamaScraper = options.ollamaScraper || new OllamaNativeScraper();
         this.cachePath = path.join(require('os').homedir(), '.llm-checker', 'ai-check-cache.json');
         
@@ -93,21 +95,31 @@ Respond with JSON only, no additional text.`;
      * discarded GPUs which the unified detector had already found (notably the
      * Windows RX 7900 XTX reported in issue #106).
      */
-    async getDetectedHardwareProfile() {
-        const detected = await this.hardwareDetector.getSystemInfo();
+    async getDetectedHardwareProfile(options = {}) {
+        const cpuOnly = Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+            ? resolveCpuOnlyMode(options.cpuOnly)
+            : this.cpuOnly;
+        const rawDetected = await this.hardwareDetector.getSystemInfo(false, { cpuOnly });
+        const detected = applyCpuOnlyOverride(rawDetected, {
+            cpuOnly,
+            source: 'ai-check'
+        });
         const summary = detected?.summary || {};
         const bestBackend = String(summary.bestBackend || '').toLowerCase();
         const runtimeBackend = String(summary.runtimeBackend || '').toLowerCase();
 
-        const normalized = this.deterministicSelector.normalizeHardwareProfile({
-            ...detected,
-            acceleration: {
-                supports_metal: bestBackend === 'metal' || runtimeBackend === 'metal',
-                supports_cuda: bestBackend === 'cuda' || runtimeBackend === 'cuda',
-                supports_rocm: bestBackend === 'rocm' || runtimeBackend === 'rocm',
-                supports_vulkan: runtimeBackend === 'vulkan'
-            }
-        });
+        const normalized = this.deterministicSelector.normalizeHardwareProfile(
+            {
+                ...detected,
+                acceleration: {
+                    supports_metal: bestBackend === 'metal' || runtimeBackend === 'metal',
+                    supports_cuda: bestBackend === 'cuda' || runtimeBackend === 'cuda',
+                    supports_rocm: bestBackend === 'rocm' || runtimeBackend === 'rocm',
+                    supports_vulkan: runtimeBackend === 'vulkan'
+                }
+            },
+            { cpuOnly }
+        );
 
         return {
             ...normalized,
@@ -133,7 +145,7 @@ Respond with JSON only, no additional text.`;
 
         // Phase 1: Detect hardware through the canonical detector used by the
         // rest of the CLI, then load all available models.
-        const hardware = await this.getDetectedHardwareProfile();
+        const hardware = await this.getDetectedHardwareProfile(options);
         
         // Use the same synced database that recommend/check use.
         const ollamaData = await this.loadModelDatabase();
@@ -435,6 +447,7 @@ Respond with JSON only, no additional text.`;
         
         return {
             hardware: {
+                cpuOnly: Boolean(hardware.cpuOnly),
                 backend: hardware.acceleration.supports_metal ? 'metal' : 
                         hardware.acceleration.supports_cuda ? 'cuda' : 'cpu',
                 usableMemGB: Math.round(hardware.usableMemGB * 10) / 10,
@@ -488,12 +501,20 @@ Return JSON with this structure:
   ]
 }`;
 
+        const hasPayloadMode = Object.prototype.hasOwnProperty.call(payload.hardware || {}, 'cpuOnly');
+        const cpuOnly = hasPayloadMode
+            ? resolveCpuOnlyMode(payload.hardware.cpuOnly)
+            : this.cpuOnly;
+        if (typeof this.ollamaClient.setCpuOnly === 'function') {
+            this.ollamaClient.setCpuOnly(cpuOnly);
+        }
         const requestBody = {
             model: modelId,
             stream: false,
             options: {
                 temperature: 0.1,
-                num_ctx: 4096
+                num_ctx: 4096,
+                ...(cpuOnly ? { num_gpu: 0 } : {})
             },
             messages: [
                 { role: 'system', content: this.systemPrompt },

--- a/src/models/deterministic-selector.js
+++ b/src/models/deterministic-selector.js
@@ -8,6 +8,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
+const { applyCpuOnlyOverride, resolveCpuOnlyMode } = require('../hardware/cpu-only');
 const { spawn } = require('child_process');
 const OllamaClient = require('../ollama/client');
 const { DETERMINISTIC_WEIGHTS } = require('./scoring-config');
@@ -22,10 +23,13 @@ const {
 } = require('./moe-assumptions');
 
 class DeterministicModelSelector {
-    constructor() {
+    constructor(options = {}) {
+        this.hasExplicitCpuOnly = Object.prototype.hasOwnProperty.call(options, 'cpuOnly');
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
+        this.activeCpuOnly = this.cpuOnly;
         this.catalogPath = path.join(__dirname, 'catalog.json');
         this.benchCachePath = path.join(os.homedir(), '.llm-checker', 'bench.json');
-        this.ollamaClient = new OllamaClient();
+        this.ollamaClient = options.ollamaClient || new OllamaClient({ cpuOnly: this.cpuOnly });
         this.ollamaCachePaths = [
             path.join(os.homedir(), '.llm-checker', 'cache', 'ollama', 'ollama-detailed-models.json'),
             path.join(__dirname, '../ollama/.cache/ollama-detailed-models.json')
@@ -174,7 +178,18 @@ class DeterministicModelSelector {
      * - gpu.vramGB
      * - acceleration.supports_*
      */
-    normalizeHardwareProfile(input = {}) {
+    normalizeHardwareProfile(input = {}, options = {}) {
+        const hasExplicitCpuOnly = Object.prototype.hasOwnProperty.call(options, 'cpuOnly');
+        const hasInputCpuOnly = Object.prototype.hasOwnProperty.call(input, 'cpuOnly');
+        const effectiveCpuOnly = hasExplicitCpuOnly
+            ? resolveCpuOnlyMode(options.cpuOnly)
+            : (hasInputCpuOnly ? resolveCpuOnlyMode(input.cpuOnly) : this.cpuOnly);
+        const shouldExposeCpuOnlyMode = hasExplicitCpuOnly || hasInputCpuOnly ||
+            this.hasExplicitCpuOnly || effectiveCpuOnly;
+        input = applyCpuOnlyOverride(input, {
+            cpuOnly: effectiveCpuOnly,
+            source: 'deterministic-selector'
+        });
         const toNumber = (value) => {
             if (typeof value === 'number' && Number.isFinite(value)) return value;
             if (typeof value === 'string' && value.trim() !== '' && Number.isFinite(Number(value))) {
@@ -277,6 +292,7 @@ class DeterministicModelSelector {
 
         return {
             ...input,
+            ...(shouldExposeCpuOnlyMode ? { cpuOnly: effectiveCpuOnly } : {}),
             cpu: {
                 ...cpu,
                 architecture: cpu.architecture || cpu.arch || process.arch || 'x86_64',
@@ -1435,8 +1451,16 @@ class DeterministicModelSelector {
         }
         
         // Phase 0: Gather data
-        const detectedHardware = providedHardware || await this.getHardware();
-        const hardware = this.normalizeHardwareProfile(detectedHardware);
+        const rawHardware = providedHardware || await this.getHardware();
+        const hardware = this.normalizeHardwareProfile(rawHardware, {
+            ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                ? { cpuOnly: options.cpuOnly }
+                : {})
+        });
+        this.activeCpuOnly = Boolean(hardware.cpuOnly);
+        if (typeof this.ollamaClient.setCpuOnly === 'function') {
+            this.ollamaClient.setCpuOnly(this.activeCpuOnly);
+        }
         const installed = Array.isArray(installedModels) ? installedModels : await this.getInstalledModels();
         const externalPool = Array.isArray(modelPool) && modelPool.length > 0
             ? (modelPool.some(model => typeof model?.paramsB === 'number' && model?.model_identifier)
@@ -1898,10 +1922,12 @@ class DeterministicModelSelector {
 
     estimateSpeedProfile(hardware, model, quant, category, runtime = 'ollama') {
         // Determine backend
+        const cpuArchitecture = String(hardware.cpu?.architecture || '').toLowerCase();
+        const isArmCpu = /(?:arm64|aarch64|apple\s+silicon)/.test(cpuArchitecture);
         let backend = 'cpu_x86';
         if (hardware.acceleration.supports_metal) backend = 'metal';
         else if (hardware.acceleration.supports_cuda) backend = 'cuda';
-        else if (hardware.cpu.architecture === 'arm64') backend = 'cpu_arm';
+        else if (isArmCpu) backend = 'cpu_arm';
         
         // Base speed calculation
         const K = this.backendK[backend];
@@ -2237,6 +2263,10 @@ class DeterministicModelSelector {
     // ============================================================================
 
     async runQuickProbes(candidates, hardware, category) {
+        this.activeCpuOnly = Boolean(hardware?.cpuOnly);
+        if (typeof this.ollamaClient.setCpuOnly === 'function') {
+            this.ollamaClient.setCpuOnly(this.activeCpuOnly);
+        }
         // Load cached results
         const cache = this.loadBenchCache();
         const hardwareFingerprint = this.getHardwareFingerprint(hardware);
@@ -2287,7 +2317,8 @@ class DeterministicModelSelector {
 
         const result = await this.ollamaClient.generate(modelId, prompt, {
             generationOptions: {
-                num_predict: targetTokens
+                num_predict: targetTokens,
+                ...(this.activeCpuOnly ? { num_gpu: 0 } : {})
             }
         });
 
@@ -2357,7 +2388,10 @@ class DeterministicModelSelector {
     }
 
     getHardwareFingerprint(hardware) {
-        return `${hardware.cpu.architecture}_${hardware.cpu.cores}c_${hardware.memory.totalGB}gb_${hardware.gpu.type}`;
+        const executionMode = hardware.cpuOnly
+            ? 'cpu-only'
+            : (hardware.summary?.bestBackend || hardware.gpu.type || 'cpu');
+        return `${hardware.cpu.architecture}_${hardware.cpu.cores}c_${hardware.memory.totalGB}gb_${executionMode}`;
     }
 
     // ============================================================================
@@ -2513,7 +2547,11 @@ class DeterministicModelSelector {
         const recommendations = {};
         const normalizedPool = this.normalizeExternalModels(Array.isArray(allModels) ? allModels : []);
         const installedModels = await this.getInstalledModels();
-        const normalizedHardware = this.normalizeHardwareProfile(hardware || await this.getHardware());
+        const normalizedHardware = this.normalizeHardwareProfile(hardware || await this.getHardware(), {
+            ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                ? { cpuOnly: options.cpuOnly }
+                : {})
+        });
         const runtime = normalizeMoERuntime(options.runtime || 'ollama');
         const optimizationObjective = this.normalizeOptimizationObjective(
             options.optimizeFor || options.optimize || options.objective
@@ -2527,6 +2565,9 @@ class DeterministicModelSelector {
                     silent: true,
                     optimizeFor: optimizationObjective,
                     runtime,
+                    ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+                        ? { cpuOnly: options.cpuOnly }
+                        : {}),
                     hardware: normalizedHardware,
                     installedModels,
                     modelPool: normalizedPool,

--- a/src/models/intelligent-selector.js
+++ b/src/models/intelligent-selector.js
@@ -12,6 +12,11 @@ const PolicyManager = require('../policy/policy-manager');
 const PolicyEngine = require('../policy/policy-engine');
 const { rankModels } = require('./scoring-core');
 const { filterModelsBySafety } = require('./model-safety');
+const {
+    applyCpuOnlyOverride,
+    getCpuOnlyMaxModelSize,
+    resolveCpuOnlyMode
+} = require('../hardware/cpu-only');
 
 function isPlainObject(value) {
     return typeof value === 'object' && value !== null && !Array.isArray(value);
@@ -19,8 +24,9 @@ function isPlainObject(value) {
 
 class IntelligentSelector {
     constructor(options = {}) {
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
         this.scoring = new ScoringEngine(options.scoring || {});
-        this.detector = options.detector || new UnifiedDetector();
+        this.detector = options.detector || new UnifiedDetector({ cpuOnly: this.cpuOnly });
         this.database = options.database || null;
         this.policyManager = options.policyManager || new PolicyManager();
         this.policyEngine = options.policyEngine || null;
@@ -62,9 +68,21 @@ class IntelligentSelector {
     async recommend(variants, options = {}) {
         // Merge with defaults
         const opts = { ...this.defaults, ...options };
+        const cpuOnly = Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+            ? resolveCpuOnlyMode(options.cpuOnly)
+            : this.cpuOnly;
+        opts.cpuOnly = cpuOnly;
 
         // Ensure hardware is detected
-        const hardware = await this.detector.detect();
+        // Pass the per-call mode into the detector so an explicit false can
+        // invalidate a cached CPU-only projection and restore the real GPU
+        // profile. Applying the projection after detection cannot reconstruct
+        // accelerator data that was already removed.
+        const rawHardware = await this.detector.detect({ cpuOnly });
+        const hardware = applyCpuOnlyOverride(rawHardware, {
+            cpuOnly,
+            source: 'intelligent-selector'
+        });
 
         // Apply filters
         const filtered = this.applyFilters(variants, opts, hardware);
@@ -106,9 +124,11 @@ class IntelligentSelector {
             categories,
             all: scoredWithPolicy.slice(0, opts.limit),
             hardware: {
-                description: this.detector.getHardwareDescription(),
-                tier: this.detector.getHardwareTier(),
-                maxSize: this.detector.getMaxModelSize(),
+                description: hardware.cpuOnly
+                    ? `${hardware.summary.cpuModel || hardware.cpu?.brand || 'CPU'} (${Math.round(hardware.summary.systemRAM)}GB RAM, forced CPU-only)`
+                    : this.detector.getHardwareDescription(),
+                tier: hardware.cpuOnly ? hardware.summary.hardwareTier : this.detector.getHardwareTier(),
+                maxSize: hardware.cpuOnly ? getCpuOnlyMaxModelSize(hardware) : this.detector.getMaxModelSize(),
                 backend: hardware.summary.bestBackend,
                 runtimeBackend: hardware.summary.runtimeBackend || hardware.summary.bestBackend
             },
@@ -150,6 +170,9 @@ class IntelligentSelector {
                     optimizeFor: opts.optimizeFor || opts.optimize || 'balanced',
                     runtime: opts.runtime || 'ollama',
                     includeUncensored: opts.includeUncensored === true,
+                    ...(Object.prototype.hasOwnProperty.call(opts, 'cpuOnly')
+                        ? { cpuOnly: opts.cpuOnly }
+                        : {}),
                     topN: scored.length
                 }
             );
@@ -279,7 +302,10 @@ class IntelligentSelector {
         });
 
         // Size filters
-        const maxSize = opts.maxSize || this.detector.getMaxModelSize() + 2;
+        const detectedMaxSize = hardware.cpuOnly
+            ? getCpuOnlyMaxModelSize(hardware)
+            : this.detector.getMaxModelSize();
+        const maxSize = opts.maxSize || detectedMaxSize + 2;
         const minSize = opts.minSize || 0;
 
         filtered = filtered.filter(v => {

--- a/src/models/scoring-core.js
+++ b/src/models/scoring-core.js
@@ -296,6 +296,9 @@ async function rankModels(models, hardware, options = {}) {
         silent: true,
         optimizeFor: options.optimizeFor || options.optimize || options.objective || 'balanced',
         runtime: options.runtime || 'ollama',
+        ...(Object.prototype.hasOwnProperty.call(options, 'cpuOnly')
+            ? { cpuOnly: options.cpuOnly }
+            : {}),
         hardware: hardware || undefined,
         installedModels: [],
         modelPool: pool,

--- a/src/models/speculative-decoding-estimator.js
+++ b/src/models/speculative-decoding-estimator.js
@@ -31,6 +31,10 @@ class SpeculativeDecodingEstimator {
             return null;
         }
 
+        if (!runtimeSupportedOnHardware(selectedRuntime, hardware)) {
+            return null;
+        }
+
         const targetParams = this.extractParams(model);
         if (!targetParams || targetParams < 2) {
             return {

--- a/src/ollama/client.js
+++ b/src/ollama/client.js
@@ -1,7 +1,12 @@
 const fetch = require('../utils/fetch');
+const { resolveCpuOnlyMode } = require('../hardware/cpu-only');
 
 class OllamaClient {
-    constructor(baseURL = null) {
+    constructor(baseURL = null, options = {}) {
+        if (baseURL && typeof baseURL === 'object') {
+            options = baseURL;
+            baseURL = options.baseURL || null;
+        }
         // Support OLLAMA_HOST environment variable (standard Ollama configuration)
         // Also support OLLAMA_BASE_URL and OLLAMA_URL for backwards compatibility
         this.preferredBaseURL = this.normalizeBaseURL(
@@ -13,6 +18,18 @@ class OllamaClient {
         this.lastCheck = 0;
         this.cacheTimeout = 30000;
         this._pendingCheck = null;
+        this.cpuOnly = resolveCpuOnlyMode(options.cpuOnly);
+    }
+
+    setCpuOnly(enabled = true) {
+        this.cpuOnly = resolveCpuOnlyMode(enabled);
+        return this;
+    }
+
+    getGenerationOptions(options = {}) {
+        return this.cpuOnly
+            ? { ...options, num_gpu: 0 }
+            : options;
     }
 
     isWildcardBindHost(hostname) {
@@ -546,8 +563,9 @@ class OllamaClient {
 
         if (keepAlive) payload.keep_alive = keepAlive;
         if (format) payload.format = format;
-        if (generationOptions && Object.keys(generationOptions).length > 0) {
-            payload.options = generationOptions;
+        const effectiveGenerationOptions = this.getGenerationOptions(generationOptions);
+        if (effectiveGenerationOptions && Object.keys(effectiveGenerationOptions).length > 0) {
+            payload.options = effectiveGenerationOptions;
         }
 
         const startTime = Date.now();
@@ -671,8 +689,9 @@ class OllamaClient {
         if (Array.isArray(tools) && tools.length > 0) payload.tools = tools;
         if (format) payload.format = format;
         if (keepAlive) payload.keep_alive = keepAlive;
-        if (generationOptions && Object.keys(generationOptions).length > 0) {
-            payload.options = generationOptions;
+        const effectiveGenerationOptions = this.getGenerationOptions(generationOptions);
+        if (effectiveGenerationOptions && Object.keys(effectiveGenerationOptions).length > 0) {
+            payload.options = effectiveGenerationOptions;
         }
 
         try {
@@ -722,8 +741,9 @@ class OllamaClient {
         if (Array.isArray(tools) && tools.length > 0) payload.tools = tools;
         if (format) payload.format = format;
         if (keepAlive) payload.keep_alive = keepAlive;
-        if (generationOptions && Object.keys(generationOptions).length > 0) {
-            payload.options = generationOptions;
+        const effectiveGenerationOptions = this.getGenerationOptions(generationOptions);
+        if (effectiveGenerationOptions && Object.keys(effectiveGenerationOptions).length > 0) {
+            payload.options = effectiveGenerationOptions;
         }
 
         const startTime = Date.now();

--- a/src/runtime/runtime-support.js
+++ b/src/runtime/runtime-support.js
@@ -40,6 +40,7 @@ function isAppleSiliconHardware(hardware = {}) {
 function runtimeSupportedOnHardware(runtime = 'ollama', hardware = {}) {
     const normalized = normalizeRuntime(runtime);
     if (normalized === 'mlx') {
+        if (hardware?.cpuOnly) return false;
         return isAppleSiliconHardware(hardware);
     }
     return true;

--- a/src/utils/token-speed-estimator.js
+++ b/src/utils/token-speed-estimator.js
@@ -161,6 +161,7 @@ function calculateMemoryFactor(modelSizeB, availableInferenceMemoryGB) {
 }
 
 function estimateTokenSpeedFromHardware(hardware = {}, options = {}) {
+    const cpuOnly = Boolean(hardware.cpuOnly);
     const cpuModel = String(hardware.cpu?.brand || hardware.cpu?.model || '');
     const gpuModel = String(hardware.gpu?.model || '');
     const architecture = String(hardware.cpu?.architecture || '');
@@ -190,8 +191,8 @@ function estimateTokenSpeedFromHardware(hardware = {}, options = {}) {
         )
     );
 
-    const appleSilicon = detectAppleSilicon(architecture, cpuModel, gpuModel);
-    const integrated = detectIntegratedGpu(hardware, gpuModel);
+    const appleSilicon = !cpuOnly && detectAppleSilicon(architecture, cpuModel, gpuModel);
+    const integrated = !cpuOnly && detectIntegratedGpu(hardware, gpuModel);
     const dedicatedGPU = detectDedicatedGpu(hardware, integrated, appleSilicon, vramGB);
 
     let baselineTPS7B;

--- a/tests/cpu-only-mode.test.js
+++ b/tests/cpu-only-mode.test.js
@@ -1,0 +1,1125 @@
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const os = require('os');
+const path = require('path');
+const { spawn, spawnSync } = require('child_process');
+
+const LLMChecker = require('../src/index');
+const CompatibilityAnalyzer = require('../analyzer/compatibility');
+const HardwareDetector = require('../src/hardware/detector');
+const {
+    CPU_ONLY_ENV,
+    applyCpuOnlyOverride,
+    getSystemRAMGB,
+    resolveCpuOnlyMode
+} = require('../src/hardware/cpu-only');
+const { buildGpuPlan } = require('../src/commands/roadmap-tools');
+const { buildFullHardwareObject } = require('../src/hardware/profiles');
+const DeterministicModelSelector = require('../src/models/deterministic-selector');
+const IntelligentSelector = require('../src/models/intelligent-selector');
+const AICheckSelector = require('../src/models/ai-check-selector');
+const AIModelSelector = require('../src/ai/model-selector');
+const OllamaClient = require('../src/ollama/client');
+const SpeculativeDecodingEstimator = require('../src/models/speculative-decoding-estimator');
+const {
+    RegistryRecommender,
+    normalizeHardwareForSelector
+} = require('../src/data/registry-recommender');
+const { runtimeSupportedOnHardware } = require('../src/runtime/runtime-support');
+const { estimateTokenSpeedFromHardware } = require('../src/utils/token-speed-estimator');
+const { rankModels } = require('../src/models/scoring-core');
+
+const ROOT = path.resolve(__dirname, '..');
+const CLI = path.join(ROOT, 'bin', 'enhanced_cli.js');
+
+function buildGpuHardware(overrides = {}) {
+    const hardware = {
+        cpu: {
+            brand: 'AMD Ryzen 9 7950X',
+            manufacturer: 'AMD',
+            architecture: 'x86_64',
+            cores: 32,
+            physicalCores: 16,
+            speed: 4.5,
+            score: 100,
+            speedCoefficient: 110,
+            capabilities: { avx2: true }
+        },
+        memory: { total: 64, totalGB: 64, free: 48 },
+        gpu: {
+            type: 'nvidia',
+            model: 'NVIDIA GeForce RTX 4090',
+            vendor: 'NVIDIA',
+            backend: 'cuda',
+            vram: 24,
+            vramGB: 24,
+            vramPerGPU: 24,
+            totalVRAM: 24,
+            dedicated: true,
+            gpuCount: 1,
+            isMultiGPU: false,
+            hasDedicatedGPU: true,
+            hasIntegratedGPU: false,
+            dedicatedGpuModels: [{ name: 'NVIDIA GeForce RTX 4090', count: 1 }],
+            integratedGpuModels: [],
+            all: [{ model: 'NVIDIA GeForce RTX 4090', vendor: 'NVIDIA', vram: 24 }]
+        },
+        acceleration: {
+            supports_cuda: true,
+            supports_rocm: false,
+            supports_metal: false,
+            supports_vulkan: true
+        },
+        primary: {
+            type: 'cuda',
+            name: 'NVIDIA CUDA',
+            info: { speedCoefficient: 250 }
+        },
+        summary: {
+            bestBackend: 'cuda',
+            backendName: 'NVIDIA CUDA',
+            bestBackendLabel: 'NVIDIA CUDA',
+            runtimeBackend: 'cuda',
+            runtimeBackendName: 'NVIDIA CUDA',
+            hasRuntimeAssist: false,
+            totalVRAM: 24,
+            effectiveMemory: 24,
+            systemRAM: 64,
+            speedCoefficient: 250,
+            hardwareTier: 'high',
+            cpuModel: 'AMD Ryzen 9 7950X',
+            isMultiGPU: false,
+            gpuCount: 1,
+            gpuModel: 'NVIDIA GeForce RTX 4090',
+            gpuInventory: 'NVIDIA GeForce RTX 4090',
+            gpuModels: [{ name: 'NVIDIA GeForce RTX 4090', count: 1 }],
+            hasHeterogeneousGPU: false,
+            hasIntegratedGPU: false,
+            hasDedicatedGPU: true,
+            integratedGpuCount: 0,
+            dedicatedGpuCount: 1,
+            integratedGpuModels: [],
+            dedicatedGpuModels: [{ name: 'NVIDIA GeForce RTX 4090', count: 1 }],
+            integratedSharedMemory: 0
+        },
+        backends: {
+            cpu: {
+                available: true,
+                info: {
+                    brand: 'AMD Ryzen 9 7950X',
+                    architecture: 'x86_64',
+                    cores: { logical: 32, physical: 16 },
+                    speedCoefficient: 110,
+                    capabilities: { avx2: true }
+                }
+            },
+            cuda: {
+                available: true,
+                info: {
+                    totalVRAM: 24,
+                    speedCoefficient: 250,
+                    gpus: [{ name: 'NVIDIA GeForce RTX 4090', memory: { total: 24 } }]
+                }
+            }
+        },
+        os: { platform: 'linux' }
+    };
+
+    return {
+        ...hardware,
+        ...overrides,
+        cpu: { ...hardware.cpu, ...(overrides.cpu || {}) },
+        memory: { ...hardware.memory, ...(overrides.memory || {}) },
+        summary: { ...hardware.summary, ...(overrides.summary || {}) }
+    };
+}
+
+function stripAnsi(text = '') {
+    return String(text).replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+function runCli(args, env = {}) {
+    return spawnSync(process.execPath, [CLI, ...args], {
+        cwd: ROOT,
+        encoding: 'utf8',
+        timeout: 45000,
+        env: {
+            ...process.env,
+            NO_COLOR: '1',
+            [CPU_ONLY_ENV]: '',
+            ...env
+        }
+    });
+}
+
+function runCliAsync(args, env = {}) {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [CLI, ...args], {
+            cwd: ROOT,
+            env: {
+                ...process.env,
+                NO_COLOR: '1',
+                [CPU_ONLY_ENV]: '',
+                ...env
+            },
+            stdio: ['ignore', 'pipe', 'pipe']
+        });
+        let stdout = '';
+        let stderr = '';
+        const timeout = setTimeout(() => {
+            child.kill('SIGKILL');
+            reject(new Error(`CLI timed out: ${args.join(' ')}`));
+        }, 45000);
+
+        child.stdout.on('data', (chunk) => { stdout += chunk; });
+        child.stderr.on('data', (chunk) => { stderr += chunk; });
+        child.once('error', (error) => {
+            clearTimeout(timeout);
+            reject(error);
+        });
+        child.once('close', (status, signal) => {
+            clearTimeout(timeout);
+            resolve({ status, signal, stdout, stderr });
+        });
+    });
+}
+
+function testProjectionUsesCpuAndRamOnly() {
+    const raw = buildGpuHardware();
+    const projected = applyCpuOnlyOverride(raw, { cpuOnly: true, source: 'test' });
+
+    assert.notStrictEqual(projected, raw);
+    assert.strictEqual(raw.summary.bestBackend, 'cuda', 'the detected profile must remain unchanged');
+    assert.strictEqual(projected.cpuOnly, true);
+    assert.strictEqual(projected.primary.type, 'cpu');
+    assert.strictEqual(projected.summary.bestBackend, 'cpu');
+    assert.strictEqual(projected.summary.runtimeBackend, 'cpu');
+    assert.strictEqual(projected.summary.totalVRAM, 0);
+    assert.strictEqual(projected.summary.gpuCount, 0);
+    assert.strictEqual(projected.summary.effectiveMemory, 45, '64GB RAM should expose a 45GB CPU model budget');
+    assert.strictEqual(projected.summary.speedCoefficient, 110, 'CPU speed must replace the GPU coefficient');
+    assert.strictEqual(projected.summary.hardwareTier, 'medium_high');
+    assert.strictEqual(projected.gpu.vramGB, 0);
+    assert.strictEqual(projected.gpu.gpuCount, 0);
+    assert.strictEqual(projected.acceleration.supports_cuda, false);
+    assert.strictEqual(projected.acceleration.supports_vulkan, false);
+    assert.strictEqual(projected.detectedGpu.totalVRAM, 24, 'real VRAM remains diagnostic');
+    assert.deepStrictEqual(
+        projected.detectedGpu.dedicatedGpuModels,
+        raw.summary.dedicatedGpuModels,
+        'diagnostics preserve dedicated inventory separately'
+    );
+    assert.strictEqual(projected.backends.cuda.available, true, 'raw backend inventory remains available for diagnostics');
+    assert.strictEqual(runtimeSupportedOnHardware('mlx', projected), false, 'CPU-only mode cannot advertise MLX GPU execution');
+
+    assert.strictEqual(
+        getSystemRAMGB({ summary: { systemRAM: null }, memory: { total: 64 } }),
+        64,
+        'null canonical fields must not become a false 0GB value'
+    );
+}
+
+function testSimulatedProfileDiagnosticInference() {
+    const rtx4090 = applyCpuOnlyOverride(buildFullHardwareObject('rtx4090'), {
+        cpuOnly: true,
+        source: 'test-simulation'
+    });
+    assert.deepStrictEqual(
+        rtx4090.detectedGpu.dedicatedGpuModels,
+        [{ name: 'NVIDIA GeForce RTX 4090', count: 1 }],
+        'a real simulation profile must infer its dedicated diagnostic inventory from gpu.all'
+    );
+    assert.deepStrictEqual(rtx4090.detectedGpu.integratedGpuModels, []);
+
+    const m4pro24 = applyCpuOnlyOverride(buildFullHardwareObject('m4pro24'), {
+        cpuOnly: true,
+        source: 'test-simulation'
+    });
+    assert.deepStrictEqual(m4pro24.detectedGpu.dedicatedGpuModels, []);
+    assert.deepStrictEqual(
+        m4pro24.detectedGpu.integratedGpuModels,
+        [{ name: 'Apple M4 Pro', count: 1 }],
+        'a real unified-memory simulation profile must retain its integrated GPU diagnostic'
+    );
+}
+
+async function testDetectorCacheAndSimulationPrecedence() {
+    const raw = buildGpuHardware();
+    const cachedDetector = new HardwareDetector({ cpuOnly: true });
+    cachedDetector.cache = raw;
+    cachedDetector.cacheTime = Date.now();
+
+    const cachedCpu = await cachedDetector.getSystemInfo();
+    assert.strictEqual(cachedCpu.summary.bestBackend, 'cpu');
+    assert.strictEqual(cachedCpu.detectedGpu.model, 'NVIDIA GeForce RTX 4090');
+
+    const cachedGpu = await cachedDetector.getSystemInfo(false, { cpuOnly: false });
+    assert.strictEqual(cachedGpu.summary.bestBackend, 'cuda', 'per-call false restores the raw cached profile');
+    assert.strictEqual(cachedGpu.summary.totalVRAM, 24);
+
+    const simulated = buildGpuHardware({
+        cpu: { brand: 'Simulated Threadripper', speedCoefficient: 120 },
+        memory: { total: 96, totalGB: 96 },
+        summary: { systemRAM: 96, cpuModel: 'Simulated Threadripper' }
+    });
+    const checker = new LLMChecker({ verbose: false, cpuOnly: true });
+    checker.setSimulatedHardware(simulated);
+
+    const simulatedCpu = await checker.getSystemInfo();
+    assert.strictEqual(simulatedCpu.cpu.brand, 'Simulated Threadripper');
+    assert.strictEqual(simulatedCpu.memory.total, 96);
+    assert.strictEqual(simulatedCpu.summary.effectiveMemory, 67);
+    assert.strictEqual(simulatedCpu.detectedGpu.model, 'NVIDIA GeForce RTX 4090');
+
+    const simulatedGpu = await checker.getSystemInfo({ cpuOnly: false });
+    assert.strictEqual(simulatedGpu.summary.bestBackend, 'cuda');
+    assert.strictEqual(simulatedGpu.memory.total, 96);
+}
+
+async function testEnvironmentOptInAndExplicitFalse() {
+    const previous = process.env[CPU_ONLY_ENV];
+    process.env[CPU_ONLY_ENV] = '1';
+    try {
+        assert.strictEqual(resolveCpuOnlyMode(), true);
+        assert.strictEqual(resolveCpuOnlyMode(false), false, 'an explicit API false overrides the environment');
+
+        const raw = buildGpuHardware();
+        const detector = new HardwareDetector();
+        detector.setSimulatedHardware(raw);
+        assert.strictEqual((await detector.getSystemInfo()).cpuOnly, true);
+        assert.strictEqual(
+            (await detector.getSystemInfo(false, { cpuOnly: false })).summary.bestBackend,
+            'cuda'
+        );
+
+        const checker = new LLMChecker({ verbose: false, cpuOnly: false });
+        checker.setSimulatedHardware(raw);
+        checker.runAnalysisFlow = async (hardware, options) => ({ hardware, options });
+        const analysis = await checker.analyze();
+        assert.strictEqual(analysis.hardware.summary.bestBackend, 'cuda');
+        assert.strictEqual(
+            analysis.options.cpuOnly,
+            false,
+            'constructor false must propagate through analyze even when the environment enables CPU-only'
+        );
+
+        const ranked = await rankModels(
+            [{ model_identifier: 'tiny:1b', name: 'Tiny 1B', paramsB: 1, sizeGB: 1, tags: ['instruct'] }],
+            raw,
+            { category: 'general', topN: 1, cpuOnly: false }
+        );
+        assert.strictEqual(ranked.hardware.cpuOnly, false);
+        assert.strictEqual(ranked.hardware.gpu.vramGB, 24);
+
+        const selector = new DeterministicModelSelector();
+        const gpuProfile = selector.normalizeHardwareProfile(raw, { cpuOnly: false });
+        assert.strictEqual(gpuProfile.cpuOnly, false);
+        assert.strictEqual(gpuProfile.gpu.vramGB, 24);
+        assert.strictEqual(gpuProfile.acceleration.supports_cuda, true);
+        assert.strictEqual(
+            selector.normalizeHardwareProfile(gpuProfile).gpu.vramGB,
+            24,
+            'an explicit-false profile marker must keep suppressing the environment downstream'
+        );
+
+        const configuredCpuSelector = new DeterministicModelSelector({ cpuOnly: true });
+        const configuredCpuProfile = configuredCpuSelector.normalizeHardwareProfile(raw);
+        assert.strictEqual(configuredCpuProfile.cpuOnly, true);
+        assert.strictEqual(configuredCpuProfile.gpu.vramGB, 0);
+        assert.strictEqual(configuredCpuProfile.acceleration.supports_cuda, false);
+
+        const configuredGpuSelector = new DeterministicModelSelector({ cpuOnly: false });
+        const configuredGpuProfile = configuredGpuSelector.normalizeHardwareProfile(raw);
+        assert.strictEqual(configuredGpuProfile.cpuOnly, false);
+        assert.strictEqual(configuredGpuProfile.gpu.vramGB, 24);
+
+        const configuredGpuSelection = await configuredGpuSelector.selectModels('general', {
+            hardware: raw,
+            installedModels: [],
+            modelPool: [{
+                model_identifier: 'tiny',
+                model_name: 'Tiny',
+                primary_category: 'general',
+                context_length: '8K',
+                variants: [{
+                    tag: 'tiny:1b',
+                    size: '1b',
+                    quantization: 'Q4_K_M',
+                    real_size_gb: 1,
+                    categories: ['general']
+                }],
+                tags: ['tiny:1b'],
+                use_cases: ['general']
+            }],
+            topN: 1,
+            silent: true
+        });
+        assert.strictEqual(configuredGpuSelection.hardware.cpuOnly, false);
+        assert.strictEqual(configuredGpuSelection.hardware.gpu.vramGB, 24);
+
+        const aiRunSelector = new AIModelSelector({ cpuOnly: false });
+        const gpuSpecs = aiRunSelector.normalizeSystemSpecs({
+            total_ram_gb: 64,
+            cpu_cores: 32,
+            gpu_vram_gb: 24,
+            gpu_model_normalized: 'rtx_4090'
+        }, { cpuOnly: false });
+        assert.strictEqual(gpuSpecs.gpu_vram_gb, 24);
+        assert.strictEqual(gpuSpecs.gpu_model_normalized, 'rtx_4090');
+
+        let smartDetectorCpuOnly = true;
+        const smartDetector = {
+            async detect(options = {}) {
+                if (Object.prototype.hasOwnProperty.call(options, 'cpuOnly')) {
+                    smartDetectorCpuOnly = resolveCpuOnlyMode(options.cpuOnly);
+                }
+                return smartDetectorCpuOnly
+                    ? applyCpuOnlyOverride(raw, { cpuOnly: true, source: 'test-detector' })
+                    : raw;
+            },
+            getHardwareDescription: () => smartDetectorCpuOnly ? 'CPU profile' : 'GPU profile',
+            getHardwareTier: () => smartDetectorCpuOnly ? 'low' : 'high',
+            getMaxModelSize: () => smartDetectorCpuOnly ? 10 : 22
+        };
+        const smartSelector = new IntelligentSelector({ cpuOnly: true, detector: smartDetector });
+        const smartGpu = await smartSelector.recommend([], {
+            cpuOnly: false,
+            policyFile: null
+        });
+        assert.strictEqual(smartDetectorCpuOnly, false);
+        assert.strictEqual(
+            smartGpu.hardware.backend,
+            'cuda',
+            'smart-recommend explicit false must restore the detector GPU profile'
+        );
+    } finally {
+        if (previous === undefined) delete process.env[CPU_ONLY_ENV];
+        else process.env[CPU_ONLY_ENV] = previous;
+    }
+}
+
+async function testRecommendationSurfaces() {
+    const raw = buildGpuHardware();
+    const projected = applyCpuOnlyOverride(raw, { cpuOnly: true });
+    const deterministic = new DeterministicModelSelector();
+    const normalized = deterministic.normalizeHardwareProfile(raw, { cpuOnly: true });
+
+    assert.strictEqual(normalized.gpu.type, 'cpu_only');
+    assert.strictEqual(normalized.gpu.vramGB, 0);
+    assert.strictEqual(normalized.gpu.gpuCount, 0);
+    assert.strictEqual(normalized.usableMemGB, 45);
+    assert.strictEqual(
+        deterministic.estimateSpeedProfile(
+            normalized,
+            { model_identifier: 'qwen:7b', paramsB: 7 },
+            'Q4_K_M',
+            'general'
+        ).backend,
+        'cpu_x86',
+        'deterministic scoring must use a CPU speed backend'
+    );
+
+    const safetyPool = [
+        {
+            model_identifier: 'safe-tiny:1b',
+            name: 'Safe Tiny 1B',
+            paramsB: 1,
+            sizeGB: 1,
+            tags: ['instruct']
+        },
+        {
+            model_identifier: 'dolphin-uncensored:1b',
+            name: 'Dolphin Uncensored 1B',
+            paramsB: 1,
+            sizeGB: 1,
+            tags: ['uncensored']
+        }
+    ];
+    const safeCpuRanking = await rankModels(safetyPool, raw, {
+        category: 'general',
+        topN: 10,
+        cpuOnly: true
+    });
+    assert.strictEqual(safeCpuRanking.hardware.cpuOnly, true);
+    const rankedIdentity = (candidate) => String(
+        candidate.meta?.model_identifier ||
+        candidate.meta?.name ||
+        candidate.model_identifier ||
+        candidate.name ||
+        ''
+    );
+    assert.ok(
+        safeCpuRanking.candidates.every((candidate) => !rankedIdentity(candidate).includes('uncensored')),
+        'CPU-only scoring must retain the default restricted-model filter'
+    );
+    const optedInCpuRanking = await rankModels(safetyPool, raw, {
+        category: 'general',
+        topN: 10,
+        cpuOnly: true,
+        includeUncensored: true
+    });
+    assert.ok(
+        optedInCpuRanking.candidates.some((candidate) => rankedIdentity(candidate).includes('uncensored')),
+        'the explicit safety opt-in must continue to work alongside CPU-only mode'
+    );
+
+    const registryHardware = normalizeHardwareForSelector(raw, { cpuOnly: true });
+    assert.strictEqual(registryHardware.cpuOnly, true);
+    assert.strictEqual(registryHardware.summary.hardwareTier, 'medium_high');
+    assert.strictEqual(registryHardware.summary.speedCoefficient, 110);
+    assert.strictEqual(registryHardware.cpu.speedCoefficient, 110);
+    assert.strictEqual(registryHardware.cpu.capabilities.avx2, true);
+    assert.strictEqual(registryHardware.gpu.vramGB, 0);
+    assert.strictEqual(registryHardware.gpu.gpuCount, 0);
+    assert.strictEqual(
+        deterministic.normalizeHardwareProfile(registryHardware).summary.hardwareTier,
+        'medium_high',
+        'registry normalization must not erase the canonical CPU-only tier'
+    );
+
+    const simulatedCpuOnly = applyCpuOnlyOverride({
+        cpu: {
+            brand: 'Simulated CPU',
+            architecture: 'x86_64',
+            cores: 16,
+            score: 98,
+            capabilities: { avx2: true }
+        },
+        memory: { total: 64 },
+        gpu: { model: 'NVIDIA GeForce RTX 4090', vram: 24 },
+        summary: {
+            bestBackend: 'cuda',
+            systemRAM: 64,
+            totalVRAM: 24,
+            effectiveMemory: 24,
+            speedCoefficient: 250,
+            hasDedicatedGPU: true,
+            dedicatedGpuModels: [{ name: 'NVIDIA GeForce RTX 4090', count: 1 }]
+        }
+    }, { cpuOnly: true });
+    const registrySimulated = normalizeHardwareForSelector(simulatedCpuOnly);
+    assert.strictEqual(registrySimulated.summary.speedCoefficient, 98);
+    assert.strictEqual(registrySimulated.summary.hardwareTier, 'medium');
+    assert.strictEqual(registrySimulated.cpu.score, 98);
+
+    const autoRuntime = RegistryRecommender.prototype.scoreAutoRuntimePool.call(
+        { selector: deterministic },
+        {
+            category: 'general',
+            limit: 1,
+            hardware: projected,
+            modelPool: []
+        }
+    );
+    assert.strictEqual(
+        autoRuntime.hardware.cpuOnly,
+        true,
+        'auto-runtime scoring must preserve an inherited CPU-only hardware marker'
+    );
+    assert.strictEqual(runtimeSupportedOnHardware('mlx', autoRuntime.hardware), false);
+
+    const smart = new IntelligentSelector({
+        cpuOnly: true,
+        detector: {
+            detect: async () => raw,
+            getHardwareDescription: () => 'GPU profile',
+            getHardwareTier: () => 'high',
+            getMaxModelSize: () => 22
+        }
+    });
+    const smartResult = await smart.recommend([], { cpuOnly: true, policyFile: null });
+    assert.strictEqual(smartResult.hardware.backend, 'cpu');
+    assert.strictEqual(smartResult.hardware.tier, 'medium_high');
+    assert.strictEqual(smartResult.hardware.maxSize, 43);
+    assert.match(smartResult.hardware.description, /forced CPU-only/);
+
+    const aiCheck = new AICheckSelector({
+        cpuOnly: true,
+        hardwareDetector: { getSystemInfo: async () => raw }
+    });
+    const aiHardware = await aiCheck.getDetectedHardwareProfile({ cpuOnly: true });
+    assert.strictEqual(aiHardware.gpu.type, 'cpu_only');
+    assert.strictEqual(aiHardware.gpu.vramGB, 0);
+    assert.strictEqual(aiHardware.acceleration.supports_cuda, false);
+    assert.strictEqual(aiHardware.usableMemGB, 45);
+
+    const aiRun = new AIModelSelector({ cpuOnly: true });
+    const cpuSpecs = aiRun.normalizeSystemSpecs({
+        total_ram_gb: 64,
+        cpu_cores: 32,
+        gpu_vram_gb: 24,
+        gpu_model_normalized: 'rtx_4090'
+    });
+    assert.strictEqual(cpuSpecs.cpu_only, true);
+    assert.strictEqual(cpuSpecs.gpu_vram_gb, 0);
+    assert.strictEqual(cpuSpecs.gpu_model_normalized, 'cpu_only');
+
+    const appleCpuOnly = applyCpuOnlyOverride({
+        cpu: {
+            brand: 'Apple M4 Pro',
+            architecture: 'Apple Silicon (ARM64)',
+            cores: 12,
+            physicalCores: 12,
+            speed: 4.5,
+            speedCoefficient: 100
+        },
+        memory: { total: 24 },
+        gpu: { model: 'Apple M4 Pro', vram: 24, unified: true },
+        summary: {
+            bestBackend: 'metal',
+            systemRAM: 24,
+            totalVRAM: 24,
+            effectiveMemory: 24,
+            speedCoefficient: 180,
+            hasIntegratedGPU: true,
+            hasDedicatedGPU: false
+        },
+        os: { platform: 'darwin' }
+    }, { cpuOnly: true });
+    const speed = estimateTokenSpeedFromHardware(appleCpuOnly, { modelSizeB: 7 });
+    assert.strictEqual(speed.backend, 'cpu', 'Apple CPU-only must not use the Metal estimator');
+    assert.ok(speed.baselineTPS7B <= 18, `CPU baseline should not retain M4 Metal speed: ${speed.baselineTPS7B}`);
+
+    const simulatedAppleProfile = deterministic.normalizeHardwareProfile(
+        buildFullHardwareObject('m4pro24'),
+        { cpuOnly: true }
+    );
+    assert.strictEqual(
+        deterministic.estimateSpeedProfile(
+            simulatedAppleProfile,
+            { model_identifier: 'qwen:7b', paramsB: 7 },
+            'Q4_K_M',
+            'general'
+        ).backend,
+        'cpu_arm',
+        'Apple Silicon CPU-only scoring must use the ARM CPU coefficient'
+    );
+    assert.strictEqual(
+        new SpeculativeDecodingEstimator().estimate({
+            model: { name: 'Llama 3.1 70B', params_b: 70 },
+            candidates: [{ name: 'Llama 3.1 8B', params_b: 8 }],
+            hardware: appleCpuOnly,
+            runtime: 'mlx'
+        }),
+        null,
+        'CPU-only mode must not advertise MLX speculative decoding'
+    );
+
+    const appleModel = {
+        name: 'Llama Test 7B',
+        size: '7B',
+        type: 'local',
+        requirements: { ram: 12, recommended_ram: 16, vram: 0, cpu_cores: 4 },
+        frameworks: ['llama.cpp', 'ollama'],
+        quantization: []
+    };
+    const compatibilityAnalyzer = new CompatibilityAnalyzer();
+    const appleCompatibility = compatibilityAnalyzer.calculateModelCompatibility(
+        simulatedAppleProfile,
+        appleModel
+    );
+    assert.ok(
+        ![...appleCompatibility.notes, ...appleCompatibility.modelSpecificRecommendations]
+            .some((message) => /metal acceleration|unified memory architecture advantage/i.test(message)),
+        'Apple CPU-only compatibility output must not advertise Metal or GPU unified-memory bonuses'
+    );
+    const appleRecommendations = compatibilityAnalyzer.generateRecommendations(
+        simulatedAppleProfile,
+        { compatible: [appleModel], marginal: [], incompatible: [] }
+    );
+    assert.ok(
+        !appleRecommendations.some((message) => /metal acceleration/i.test(message)),
+        'Apple CPU-only global recommendations must not advertise Metal acceleration'
+    );
+
+    const routeChecker = new LLMChecker({ verbose: false, cpuOnly: true });
+    routeChecker.analyzeWithMathematicalHeuristics = async () => ({ route: 'mathematical' });
+    const routed = await routeChecker.analyzeWithPlatformSpecificHeuristics(
+        simulatedAppleProfile,
+        [],
+        {},
+        'apple_silicon',
+        { cpuOnly: true }
+    );
+    assert.strictEqual(
+        routed.route,
+        'mathematical',
+        'Apple CPU-only analysis must skip optimistic Metal/unified-memory post-processing'
+    );
+
+    assert.strictEqual(projected.summary.bestBackend, 'cpu');
+}
+
+async function testMultiObjectiveFallbackStaysCpuOnlyOnApple() {
+    const scoringCorePath = require.resolve('../src/models/scoring-core');
+    const multiObjectivePath = require.resolve('../src/ai/multi-objective-selector');
+    const scoringCore = require(scoringCorePath);
+    const originalRankModels = scoringCore.rankModels;
+
+    scoringCore.rankModels = async () => {
+        throw new Error('forced canonical rank failure');
+    };
+    delete require.cache[multiObjectivePath];
+
+    try {
+        const MultiObjectiveSelector = require(multiObjectivePath);
+        const selector = new MultiObjectiveSelector();
+        const hardware = applyCpuOnlyOverride({
+            cpu: {
+                brand: 'Apple M4 Pro',
+                architecture: 'Apple Silicon (ARM64)',
+                cores: 12,
+                physicalCores: 12,
+                speed: 4.5,
+                speedCoefficient: 100
+            },
+            memory: { total: 24 },
+            gpu: { model: 'Apple M4 Pro', vram: 24, unified: true },
+            summary: {
+                bestBackend: 'metal',
+                runtimeBackend: 'metal',
+                systemRAM: 24,
+                totalVRAM: 24,
+                effectiveMemory: 24,
+                speedCoefficient: 180,
+                hardwareTier: 'high',
+                hasIntegratedGPU: true,
+                hasDedicatedGPU: false
+            },
+            os: { platform: 'darwin' }
+        }, { cpuOnly: true });
+
+        assert.strictEqual(hardware.summary.hardwareTier, 'medium_high');
+        assert.strictEqual(selector.getHardwareTier(hardware), 'medium');
+        assert.strictEqual(selector.getAvailableModelMemoryGB(hardware), 17);
+        assert.strictEqual(
+            selector.estimateTTFB(hardware, { name: 'Qwen 7B', size: '4GB' }),
+            400,
+            'legacy TTFB must use CPU load latency even though a projected gpu object exists'
+        );
+        assert.ok(
+            selector.estimateTokensPerSecond(hardware, { name: 'Qwen 7B', size: '7B' }) <= 30,
+            'legacy speed fallback must stay within the CPU ceiling'
+        );
+
+        const result = await selector.selectBestModels(
+            hardware,
+            [{ name: 'TinyLlama 1B', size: '1B', context: 4096, requirements: { ram: 2 } }],
+            'general',
+            5,
+            { cpuOnly: true }
+        );
+        assert.strictEqual(
+            result.compatible.length + result.marginal.length + result.incompatible.length,
+            1,
+            'forced canonical failure should complete through the CPU-only legacy path'
+        );
+
+        const rawGpu = buildGpuHardware();
+        const rawFallback = await selector.selectBestModels(
+            rawGpu,
+            [{ name: 'Qwen 32B', size: '32B', context: 4096, requirements: { ram: 22 } }],
+            'general',
+            5,
+            { cpuOnly: true }
+        );
+        assert.strictEqual(
+            rawFallback.compatible.length,
+            0,
+            'legacy fallback must project raw GPU hardware when cpuOnly is requested per call'
+        );
+    } finally {
+        scoringCore.rankModels = originalRankModels;
+        delete require.cache[multiObjectivePath];
+    }
+}
+
+function testCpuGpuPlan() {
+    const plan = buildGpuPlan(buildGpuHardware(), { cpuOnly: true, modelSizeGB: 16 });
+    assert.strictEqual(plan.cpuOnly, true);
+    assert.strictEqual(plan.backend, 'cpu');
+    assert.strictEqual(plan.memoryType, 'system_ram');
+    assert.strictEqual(plan.memoryBudgetGB, 45);
+    assert.strictEqual(plan.cpuMaxModelGB, 43);
+    assert.strictEqual(plan.gpuCount, 0);
+    assert.deepStrictEqual(plan.gpus, []);
+    assert.strictEqual(plan.totalVRAM, 0);
+    assert.strictEqual(plan.strategy, 'cpu_only');
+    assert.strictEqual(plan.fit.fitsCPU, true);
+    assert.strictEqual(plan.fit.fitsSingleGPU, false);
+    assert.strictEqual(plan.env.OLLAMA_SCHED_SPREAD, '0');
+    assert.strictEqual(plan.detectedGpu.totalVRAM, 24);
+}
+
+async function testProbeModeAndCacheIsolation() {
+    const calls = [];
+    const fakeClient = {
+        cpuOnly: false,
+        setCpuOnly(enabled) {
+            this.cpuOnly = enabled;
+            calls.push({ type: 'mode', enabled });
+            return this;
+        },
+        async generate(model, prompt, options) {
+            calls.push({ type: 'generate', model, options, cpuOnly: this.cpuOnly });
+            return { tokensPerSecond: 7 };
+        }
+    };
+    const selector = new DeterministicModelSelector({ cpuOnly: true, ollamaClient: fakeClient });
+    let savedCache = null;
+    selector.loadBenchCache = () => ({});
+    selector.saveBenchCache = (cache) => { savedCache = cache; };
+
+    const hardware = selector.normalizeHardwareProfile(buildGpuHardware(), { cpuOnly: true });
+    const result = await selector.selectModels('general', {
+        hardware: buildGpuHardware(),
+        cpuOnly: true,
+        enableProbe: true,
+        installedModels: [],
+        modelPool: [{
+            model_identifier: 'tiny',
+            model_name: 'Tiny',
+            description: 'CPU probe fixture',
+            primary_category: 'general',
+            context_length: '8K',
+            variants: [{
+                tag: 'tiny:1b',
+                size: '1b',
+                quantization: 'Q4_K_M',
+                real_size_gb: 1,
+                categories: ['general']
+            }],
+            tags: ['tiny:1b'],
+            use_cases: ['general']
+        }],
+        topN: 1,
+        silent: true
+    });
+    assert.strictEqual(result.candidates.length, 1);
+    const generation = calls.find((call) => call.type === 'generate');
+    assert.ok(generation, 'enableProbe path should execute the Ollama generation probe');
+    assert.strictEqual(generation.cpuOnly, true);
+    assert.strictEqual(generation.options.generationOptions.num_gpu, 0);
+
+    const cpuFingerprint = selector.getHardwareFingerprint(hardware);
+    const gpuFingerprint = selector.getHardwareFingerprint(
+        selector.normalizeHardwareProfile(buildGpuHardware(), { cpuOnly: false })
+    );
+    assert.match(cpuFingerprint, /cpu-only$/);
+    assert.notStrictEqual(cpuFingerprint, gpuFingerprint, 'CPU-only and GPU probe cache keys must not collide');
+    assert.ok(
+        Object.keys(savedCache || {}).some((key) => key.startsWith(`${cpuFingerprint}_`)),
+        'measured CPU-only TPS must be cached under the CPU-only fingerprint'
+    );
+}
+
+async function testOllamaCpuOnlyEnforcement() {
+    const requests = [];
+    const server = http.createServer((request, response) => {
+        let body = '';
+        request.setEncoding('utf8');
+        request.on('data', (chunk) => { body += chunk; });
+        request.on('end', () => {
+            if (request.url === '/api/version') {
+                response.writeHead(200, { 'Content-Type': 'application/json' });
+                response.end(JSON.stringify({ version: 'test' }));
+                return;
+            }
+            if (request.url === '/api/tags') {
+                response.writeHead(200, { 'Content-Type': 'application/json' });
+                response.end(JSON.stringify({ models: [] }));
+                return;
+            }
+
+            const payload = body ? JSON.parse(body) : {};
+            requests.push({ url: request.url, payload });
+            response.writeHead(200, { 'Content-Type': 'application/json' });
+            if (request.url === '/api/chat' && payload.stream) {
+                response.end(`${JSON.stringify({
+                    message: { role: 'assistant', content: 'ok' },
+                    done: true,
+                    eval_count: 1,
+                    eval_duration: 100000000
+                })}\n`);
+            } else if (request.url === '/api/chat') {
+                response.end(JSON.stringify({
+                    message: { content: '{"winner":"tiny:1b","ranking":[{"name":"tiny:1b","aiScore":90,"shortWhy":"fit"}]}' }
+                }));
+            } else {
+                response.end(JSON.stringify({
+                    response: 'ok',
+                    eval_count: 1,
+                    eval_duration: 100000000
+                }));
+            }
+        });
+    });
+
+    await new Promise((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', resolve);
+    });
+
+    const fakeBinDir = fs.mkdtempSync(path.join(os.tmpdir(), 'llm-checker-cpu-only-bin-'));
+    const fakeOllamaPath = path.join(fakeBinDir, 'ollama');
+    fs.writeFileSync(fakeOllamaPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 });
+
+    try {
+        const port = server.address().port;
+        const baseURL = `http://127.0.0.1:${port}`;
+        const client = new OllamaClient({ baseURL, cpuOnly: true });
+
+        await client.generate('tiny:1b', 'prompt', { generationOptions: { num_gpu: 99 } });
+        await client.chat('tiny:1b', [{ role: 'user', content: 'prompt' }]);
+        await client.streamChat('tiny:1b', [{ role: 'user', content: 'prompt' }]);
+        await client.testModelPerformance('tiny:1b', 'benchmark');
+
+        assert.strictEqual(requests.length, 4);
+        for (const request of requests) {
+            assert.strictEqual(
+                request.payload.options?.num_gpu,
+                0,
+                `${request.url} must enforce num_gpu=0 in CPU-only mode`
+            );
+        }
+
+        const explicitGpuAiCheck = new AICheckSelector({ cpuOnly: true, ollamaClient: client });
+        await explicitGpuAiCheck.callOllamaEvaluator('tiny:1b', {
+            hardware: { category: 'general', cpuOnly: false },
+            candidates: [{ name: 'tiny:1b', paramsB: 1, quant: 'Q4', requiredGB: 1, installed: true }]
+        });
+        const explicitGpuRequest = requests[requests.length - 1];
+        assert.strictEqual(explicitGpuRequest.url, '/api/chat');
+        assert.strictEqual(
+            Object.prototype.hasOwnProperty.call(explicitGpuRequest.payload.options || {}, 'num_gpu'),
+            false,
+            'AI Check per-call false must override a CPU-only selector/client'
+        );
+
+        let evaluatorOptions = null;
+        const aiCheck = new AICheckSelector({
+            cpuOnly: false,
+            ollamaClient: {
+                async chat(model, messages, options) {
+                    evaluatorOptions = options;
+                    return {
+                        message: {
+                            content: '{"winner":"tiny:1b","ranking":[{"name":"tiny:1b","aiScore":90,"shortWhy":"fit"}]}'
+                        }
+                    };
+                }
+            }
+        });
+        await aiCheck.callOllamaEvaluator('tiny:1b', {
+            hardware: { category: 'general', cpuOnly: true },
+            candidates: [{ name: 'tiny:1b', paramsB: 1, quant: 'Q4', requiredGB: 1, installed: true }]
+        });
+        assert.strictEqual(
+            evaluatorOptions.generationOptions.num_gpu,
+            0,
+            'AI Check evaluator must force num_gpu=0 for a per-call CPU-only profile'
+        );
+
+        const cliEnv = {
+            OLLAMA_HOST: baseURL,
+            PATH: `${fakeBinDir}${path.delimiter}${process.env.PATH}`
+        };
+        const requestsBeforeAiRun = requests.length;
+        const benchmarkRun = await runCliAsync([
+            'ai-run',
+            '--models', 'tiny:1b',
+            '--cpu-only',
+            '--benchmark',
+            '--reference-only'
+        ], cliEnv);
+        assert.strictEqual(
+            benchmarkRun.status,
+            0,
+            stripAnsi(`${benchmarkRun.stdout}\n${benchmarkRun.stderr}`)
+        );
+
+        const promptRun = await runCliAsync([
+            'ai-run',
+            '--models', 'tiny:1b',
+            '--cpu-only',
+            '--prompt', 'say ok'
+        ], cliEnv);
+        assert.strictEqual(promptRun.status, 0, stripAnsi(`${promptRun.stdout}\n${promptRun.stderr}`));
+
+        const aiRunRequests = requests.slice(requestsBeforeAiRun)
+            .filter((request) => ['/api/generate', '/api/chat'].includes(request.url));
+        assert.ok(
+            aiRunRequests.some((request) => request.url === '/api/generate'),
+            'ai-run --benchmark should reach the fake Ollama generate endpoint'
+        );
+        assert.ok(
+            aiRunRequests.some((request) => request.url === '/api/chat' && request.payload.stream),
+            'ai-run --prompt should reach the fake Ollama streaming chat endpoint'
+        );
+        assert.ok(
+            aiRunRequests.every((request) => request.payload.options?.num_gpu === 0),
+            'every ai-run inference request must carry num_gpu=0'
+        );
+
+        const humanRecommend = await runCliAsync([
+            'recommend',
+            '--simulate', 'rtx4090',
+            '--cpu-only',
+            '--runtime', 'mlx',
+            '--no-registry',
+            '--no-verbose',
+            '--category', 'general'
+        ], cliEnv);
+        const humanOutput = stripAnsi(`${humanRecommend.stdout}\n${humanRecommend.stderr}`);
+        assert.strictEqual(humanRecommend.status, 0, humanOutput);
+        assert.match(humanOutput, /GPU:\s+Disabled by CPU-only mode/);
+        assert.match(humanOutput, /Backend:\s+CPU/);
+        assert.match(humanOutput, /VRAM:\s+Disabled \(CPU-only\)/);
+        assert.ok(!humanOutput.includes('N/AGB (Integrated)'), humanOutput);
+        assert.match(
+            humanOutput,
+            /Dedicated GPUs \(diagnostic\):\s+NVIDIA GeForce RTX 4090/,
+            'the simulated RTX inventory must remain visible as diagnostics'
+        );
+        assert.match(humanOutput, /Runtime:\s+OLLAMA/);
+        assert.ok(
+            humanOutput.includes('MLX-LM is not compatible') && humanOutput.includes('using Ollama instead'),
+            'human recommend output should explain the incompatible runtime fallback'
+        );
+
+        const humanAppleRecommend = await runCliAsync([
+            'recommend',
+            '--simulate', 'm4pro24',
+            '--cpu-only',
+            '--runtime', 'auto',
+            '--no-registry',
+            '--no-verbose',
+            '--category', 'general'
+        ], cliEnv);
+        const appleOutput = stripAnsi(
+            `${humanAppleRecommend.stdout}\n${humanAppleRecommend.stderr}`
+        );
+        assert.strictEqual(humanAppleRecommend.status, 0, appleOutput);
+        assert.match(
+            appleOutput,
+            /Integrated GPUs \(diagnostic\):\s+Apple M4 Pro/,
+            'the simulated unified GPU inventory must remain visible as diagnostics'
+        );
+    } finally {
+        await new Promise((resolve) => server.close(resolve));
+        fs.rmSync(fakeBinDir, { recursive: true, force: true });
+    }
+}
+
+function testCliHelpAndJsonSmoke() {
+    const commands = [
+        'check',
+        'recommend',
+        'ai-check',
+        'ai-run',
+        'registry-recommend',
+        'smart-recommend',
+        'gpu-plan',
+        'hw-detect'
+    ];
+
+    for (const command of commands) {
+        const result = runCli([command, '--help']);
+        const output = stripAnsi(`${result.stdout}\n${result.stderr}`);
+        assert.strictEqual(result.status, 0, `${command} --help failed: ${output}`);
+        assert.ok(output.includes('--cpu-only'), `${command} --help must expose --cpu-only`);
+    }
+
+    const planResult = runCli(['gpu-plan', '--cpu-only', '--model-size', '1GB', '--json']);
+    assert.strictEqual(planResult.status, 0, stripAnsi(planResult.stderr || planResult.stdout));
+    const plan = JSON.parse(stripAnsi(planResult.stdout));
+    assert.strictEqual(plan.cpuOnly, true);
+    assert.strictEqual(plan.backend, 'cpu');
+    assert.strictEqual(plan.gpuCount, 0);
+    assert.strictEqual(plan.totalVRAM, 0);
+
+    const detectResult = runCli(['hw-detect', '--json'], { [CPU_ONLY_ENV]: '1' });
+    assert.strictEqual(detectResult.status, 0, stripAnsi(detectResult.stderr || detectResult.stdout));
+    const detected = JSON.parse(stripAnsi(detectResult.stdout));
+    assert.strictEqual(detected.cpuOnly, true);
+    assert.strictEqual(detected.summary.bestBackend, 'cpu');
+    assert.strictEqual(detected.summary.totalVRAM, 0);
+    assert.ok(detected.detectedGpu, 'JSON diagnostics should retain the detected GPU record');
+
+    const appleCheckResult = runCli([
+        'check',
+        '--simulate', 'm4pro24',
+        '--cpu-only',
+        '--no-verbose'
+    ]);
+    const appleCheckOutput = stripAnsi(
+        `${appleCheckResult.stdout}\n${appleCheckResult.stderr}`
+    );
+    assert.strictEqual(appleCheckResult.status, 0, appleCheckOutput);
+    assert.ok(!/metal acceleration/i.test(appleCheckOutput), appleCheckOutput);
+    assert.ok(!/unified memory architecture advantage/i.test(appleCheckOutput), appleCheckOutput);
+
+    const registryMlxResult = runCli([
+        'registry-recommend',
+        '--cpu-only',
+        '--runtime', 'mlx',
+        '--limit', '3',
+        '--json'
+    ]);
+    assert.strictEqual(
+        registryMlxResult.status,
+        0,
+        stripAnsi(registryMlxResult.stderr || registryMlxResult.stdout)
+    );
+    const registryMlx = JSON.parse(stripAnsi(registryMlxResult.stdout));
+    assert.strictEqual(registryMlx.runtime, 'ollama');
+    assert.ok(registryMlx.recommendations.length > 0);
+    assert.ok(
+        registryMlx.recommendations.every((recommendation) => recommendation.runtime === 'ollama'),
+        'an explicit MLX registry request must fall back to CPU-compatible Ollama artifacts'
+    );
+
+    const registryAutoResult = runCli([
+        'registry-recommend',
+        '--cpu-only',
+        '--runtime', 'auto',
+        '--limit', '10',
+        '--json'
+    ]);
+    assert.strictEqual(
+        registryAutoResult.status,
+        0,
+        stripAnsi(registryAutoResult.stderr || registryAutoResult.stdout)
+    );
+    const registryAuto = JSON.parse(stripAnsi(registryAutoResult.stdout));
+    assert.ok(registryAuto.recommendations.length > 0);
+    assert.ok(
+        registryAuto.recommendations.every((recommendation) => recommendation.runtime !== 'mlx'),
+        'auto runtime must exclude MLX artifacts in CPU-only mode'
+    );
+}
+
+async function run() {
+    testProjectionUsesCpuAndRamOnly();
+    testSimulatedProfileDiagnosticInference();
+    await testDetectorCacheAndSimulationPrecedence();
+    await testEnvironmentOptInAndExplicitFalse();
+    await testRecommendationSurfaces();
+    await testMultiObjectiveFallbackStaysCpuOnlyOnApple();
+    testCpuGpuPlan();
+    await testProbeModeAndCacheIsolation();
+    await testOllamaCpuOnlyEnforcement();
+    testCliHelpAndJsonSmoke();
+    console.log('cpu-only-mode.test.js: OK');
+}
+
+if (require.main === module) {
+    run().catch((error) => {
+        console.error('cpu-only-mode.test.js: FAILED');
+        console.error(error);
+        process.exit(1);
+    });
+}
+
+module.exports = { run };

--- a/tests/mcp-server.test.mjs
+++ b/tests/mcp-server.test.mjs
@@ -19,6 +19,8 @@ import {
   tokensPerSecond,
   formatTokPerSec,
   mapHardwareJson,
+  buildOllamaGenerationPayload,
+  applyCpuOnlyOptimizationEnv,
   detectFrameworkMarker,
   FRAMEWORK_MARKERS,
   ALLOWED_CLI_COMMANDS,
@@ -113,6 +115,26 @@ try {
   // VRAM-derived fallback when effectiveMemory is absent.
   const vramOnly = mapHardwareJson({ summary: { totalVRAM: 12 } });
   assert.strictEqual(vramOnly.maxGB, 10, `maxGB must be 10 (12 - 2) when only totalVRAM present, got ${vramOnly.maxGB}`);
+
+  const gpuPayload = { model: "tiny:1b", options: { temperature: 0.2, num_gpu: 99 } };
+  assert.strictEqual(
+    buildOllamaGenerationPayload(gpuPayload, false),
+    gpuPayload,
+    "normal MCP generation must preserve the original payload"
+  );
+  assert.deepStrictEqual(
+    buildOllamaGenerationPayload(gpuPayload, true),
+    { model: "tiny:1b", options: { temperature: 0.2, num_gpu: 0 } },
+    "CPU-only MCP generation must force num_gpu=0 without dropping other options"
+  );
+  assert.deepStrictEqual(
+    applyCpuOnlyOptimizationEnv(
+      { OLLAMA_NUM_GPU: "999", OLLAMA_FLASH_ATTENTION: "1", OLLAMA_NUM_PARALLEL: "2" },
+      true
+    ),
+    { OLLAMA_NUM_GPU: "0", OLLAMA_FLASH_ATTENTION: "0", OLLAMA_NUM_PARALLEL: "2" },
+    "MCP optimization must not recommend GPU layers or Flash Attention in CPU-only mode"
+  );
 
   // (d) M7: framework detector must recognize ".github" as "GitHub Actions"
   // (regression for the dotfile-skip-before-detection bug).

--- a/tests/run-all-tests.js
+++ b/tests/run-all-tests.js
@@ -13,6 +13,7 @@ const TESTS = [
     { name: 'Hardware simulation scoring', file: 'hardware-simulation-tests.js', category: 'Hardware' },
     { name: 'Hardware detector regression', file: 'hardware-detector-regression.js', category: 'Hardware' },
     { name: 'Hardware tier consistency', file: 'hardware-tier-consistency.test.js', category: 'Hardware' },
+    { name: 'CPU-only execution mode', file: 'cpu-only-mode.test.js', category: 'Hardware' },
     { name: 'ROCm VRAM parsing regression', file: 'rocm-vram-parsing.test.js', category: 'Hardware' },
     { name: 'High-end / multi-GPU VRAM detection', file: 'hardware-vram-highend.test.js', category: 'Hardware' },
     { name: 'CPU detector Windows fallback', file: 'cpu-detector-windows-fallback.test.js', category: 'Hardware' },


### PR DESCRIPTION
## Summary

- add `--cpu-only` to check, recommend, ai-check, ai-run, registry-recommend, smart-recommend, gpu-plan, and hw-detect, plus `LLM_CHECKER_CPU_ONLY=1` and programmatic `cpuOnly`
- preserve the detected GPU as diagnostics while setting active VRAM/GPU count to zero and basing fit, tier, scoring, planning, and speed estimates on CPU plus system RAM
- force real Ollama execution through `num_gpu: 0`, including AI Run, AI Check, probes, MCP run/benchmark/compare, and prevent MCP optimizer from recommending GPU layers
- exclude accelerator-only MLX and speculative-decoding paths, and suppress Metal/unified-memory bonuses in Apple CPU-only mode
- keep explicit `cpuOnly: false` overrides, detector cache isolation, simulated hardware, default safe-model filtering, and normal GPU behavior intact

## Validation

- `npm test` — 57/57 passing
- `node tests/cpu-only-mode.test.js`
- `node tests/mcp-server.test.mjs`
- `node tests/default-model-safety.test.js`
- focused scoring, registry, AI Check, hardware, roadmap, and runtime regressions
- `npm pack --dry-run`
- `git diff --check`

Fixes #115